### PR TITLE
quoted source_path/VERSION in `cut` command in case of paths with quotes

### DIFF
--- a/configure
+++ b/configure
@@ -1371,7 +1371,7 @@ fi
 
 # Consult white-list to determine whether to enable werror
 # by default.  Only enable by default for git builds
-z_version=`cut -f3 -d. $source_path/VERSION`
+z_version=`cut -f3 -d. "$source_path/VERSION"`
 
 if test -z "$werror" ; then
     if test -d "$source_path/.git" -a \


### PR DESCRIPTION
When I tried to run ./configure on a Windows 8.1 machine with msysGit, it failed with the error "cut: /c/Program: No such file or directory\
cut: Archives/Programs/qemu/VERSION: No such file or directory". I determined it was because the call to `cut` in this file wasn't built for spaces, so I quoted it and here we are.
I have not tested it with any other OS, but it should work on other Windows versions, the latest Mac OS X and the main Linuxes.