### PR TITLE
configure: fix duplicate of -lrt flag

### DIFF
--- a/configure
+++ b/configure
@@ -2808,8 +2808,8 @@ if compile_prog "" "" ; then
   :
 # we need pthread for static linking. use previous pthread test result
 elif compile_prog "" "-lrt $pthread_lib" ; then
-  LIBS="-lrt $LIBS"
-  libs_qga="-lrt $libs_qga"
+  LIBS="$LIBS -lrt"
+  libs_qga="$libs_qga -lrt"
 fi
 
 if test "$darwin" != "yes" -a "$mingw32" != "yes" -a "$solaris" != yes -a \


### PR DESCRIPTION
'-lrt' flag duplication would cause 'undefined reference to clock_gettime' error
during compilation time.

Before fix:
... -o qemu-bridge-helper qemu-bridge-helper.o    -lrt -pthread -lgthread-2.0 -lrt -lglib-2.0
After fix:
... -o qemu-bridge-helper qemu-bridge-helper.o    -pthread -lgthread-2.0 -lrt -lglib-2.0

Reference:
http://hi.baidu.com/sanitywolf/item/7a8b69c1e76dd220a0b50ab1
