### PR TITLE
Fix buffer overflow on 'host'

### DIFF
--- a/util/qemu-sockets.c
+++ b/util/qemu-sockets.c
@@ -502,8 +502,8 @@ InetSocketAddress *inet_parse(const char *str, Error **errp)
 {
     InetSocketAddress *addr;
     const char *optstr, *h;
-    char host[64];
-    char port[33];
+    char host[64+1];
+    char port[32+1];
     int to;
     int pos;
 


### PR DESCRIPTION
The 'host' buffer was not large enough to accommodate 64 bytes plus a NULL terminator.  Change notation for clarity.