### PR TITLE
fix QED flush: QED did not perform proper flush

### DIFF
--- a/block/qed.c
+++ b/block/qed.c
@@ -1634,6 +1634,12 @@ static int bdrv_qed_check(BlockDriverState *bs, BdrvCheckResult *result,
     return qed_check(s, result, !!fix);
 }
 
+static BlockDriverAIOCB *bdrv_qed_aio_flush(BlockDriverState *bs,
+        BlockDriverCompletionFunc *cb, void *opaque)
+{
+    return bdrv_aio_flush(bs->file, cb, opaque);
+}
+
 static QemuOptsList qed_create_opts = {
     .name = "qed-create-opts",
     .head = QTAILQ_HEAD_INITIALIZER(qed_create_opts.head),
@@ -1694,6 +1700,7 @@ static BlockDriver bdrv_qed = {
     .bdrv_check               = bdrv_qed_check,
     .bdrv_detach_aio_context  = bdrv_qed_detach_aio_context,
     .bdrv_attach_aio_context  = bdrv_qed_attach_aio_context,
+    .bdrv_aio_flush           = bdrv_qed_aio_flush,
 };
 
 static void bdrv_qed_init(void)


### PR DESCRIPTION
Sorry I misunderstood qed... Please ignore this request!!

fix QED flush: QED did not perform proper flush on synchronized write or flush, at least one flush method should be provided (common/co/aio)'

I was doing "sync write" benchmarking on varies qemu supported formats (on ssd). I was surprised that QED shows significant high performance over several other formats (qcow2/vmdk/vdi..). In some testcases QED even runs a little bit faster than raw format!

After careful reading of the code I found QED skipped the necessary flush by providing nothing on *flush* api. unlike read/write which require at least one type of implementation, flush API is not mandatory in API because your format could guarantee that synchronization is done in write path. However that's not the case in QED because data is buffered in the backing file and need proper flush to make it safe.

However I'm not a skilled qemu developer. Above is what I got from my thinking and study. Please correct me if I misunderstood the system. 

Thanks!
Xingbo
(It's quite a hard work to go through the long callback chain, though much easier that tcg's heavy use of glue macros...) 