### PR TITLE
FPMaxNormal should be returned instead of FPInfinity vcvt[t|b] instructions (to half precision) when roundingMode is round-to-zero.

### DIFF
--- a/fpu/softfloat.c
+++ b/fpu/softfloat.c
@@ -3258,7 +3258,7 @@ static float32 roundAndPackFloat16(flag zSign, int_fast16_t zExp,
     if (zExp > maxexp || (zExp == maxexp && rounding_bumps_exp)) {
         if (ieee) {
             float_raise(float_flag_overflow | float_flag_inexact STATUS_VAR);
-            if (roundingMode == float_round_to_zero) {
+            if (STATUS(float_rounding_mode) == float_round_to_zero) {
                 /*overflow_to_inf is FALSE, return FPMaxNormal (Sign)*/
                 return packFloat16(zSign, 0x1e, 0x3ff);
             } else {

--- a/fpu/softfloat.c
+++ b/fpu/softfloat.c
@@ -3258,7 +3258,13 @@ static float32 roundAndPackFloat16(flag zSign, int_fast16_t zExp,
     if (zExp > maxexp || (zExp == maxexp && rounding_bumps_exp)) {
         if (ieee) {
             float_raise(float_flag_overflow | float_flag_inexact STATUS_VAR);
-            return packFloat16(zSign, 0x1f, 0);
+            if (roundingMode == float_round_to_zero) {
+                /*overflow_to_inf is FALSE, return FPMaxNormal (Sign)*/
+                return packFloat16(zSign, 0x1e, 0x3ff);
+            } else {
+                /*overflow_to_inf is TRUE, return FPInfinity (Sign)*/
+                return packFloat16(zSign, 0x1f, 0);
+            }
         } else {
             float_raise(float_flag_invalid STATUS_VAR);
             return packFloat16(zSign, 0x1f, 0x3ff);


### PR DESCRIPTION
The inconsistency with real device has existed since time ago. ARMv8 has enabled double-precision to half-precision - vcvt[t|b].f16.f64 also exposes such bug.

According to Page.5020 (DDI0487A), in FPRound():
// Deal with overflow and generate result.
if N != 16 || fpcr.AHP == '0' then // Single, double or IEEE half precision
  if biased_exp >= 2^E - 1 then
    result = if overflow_to_inf then FPInfinity(sign) else FPMaxNormal(sign);
    FPProcessException(FPExc_Overflow, fpcr);
    error = 1.0; // Ensure that an Inexact exception occurs
  else
    result = sign : biased_expN-F-2:0 : int_mantF-1:0;

When round-to-zero, overflow_to_inf is FALSE, FPMaxNormal should be returned.