### PR TITLE
Update qmp.py

### DIFF
--- a/scripts/qmp/qmp.py
+++ b/scripts/qmp/qmp.py
@@ -132,9 +132,12 @@ class QEMUMonitorProtocol:
 
     def command(self, cmd, **kwds):
         ret = self.cmd(cmd, kwds)
-        if ret.has_key('error'):
-            raise Exception(ret['error']['desc'])
-        return ret['return']
+        if not ret:
+            return
+        else:
+            if ret.has_key('error'):
+                raise Exception(ret['error']['desc'])
+            return ret['return']
 
     def pull_event(self, wait=False):
         """


### PR DESCRIPTION
When executing the command powerdown, the value of ret will got an instance of NoneType, then ret.has_key will raise an error, so i propose it will be better check the value of ret before using it.