### PR TITLE
nbd_init: provide diagnostic output on failure

### DIFF
--- a/nbd.c
+++ b/nbd.c
@@ -635,7 +635,7 @@ int nbd_init(int fd, int csock, uint32_t flags, off_t size, size_t blocksize)
 
     if (ioctl(fd, NBD_SET_SOCK, csock) < 0) {
         int serrno = errno;
-        LOG("Failed to set NBD socket");
+        LOG("Failed to set NBD socket: %s", strerror(serrno));
         return -serrno;
     }
 
@@ -643,7 +643,7 @@ int nbd_init(int fd, int csock, uint32_t flags, off_t size, size_t blocksize)
 
     if (ioctl(fd, NBD_SET_BLKSIZE, blocksize) < 0) {
         int serrno = errno;
-        LOG("Failed setting NBD block size");
+        LOG("Failed setting NBD block size: %s", strerror(serrno));
         return -serrno;
     }
 
@@ -651,7 +651,7 @@ int nbd_init(int fd, int csock, uint32_t flags, off_t size, size_t blocksize)
 
     if (ioctl(fd, NBD_SET_SIZE_BLOCKS, size / blocksize) < 0) {
         int serrno = errno;
-        LOG("Failed setting size (in blocks)");
+        LOG("Failed setting size (in blocks): %s", strerror(serrno));
         return -serrno;
     }
 
@@ -662,12 +662,12 @@ int nbd_init(int fd, int csock, uint32_t flags, off_t size, size_t blocksize)
 
             if (ioctl(fd, BLKROSET, (unsigned long) &read_only) < 0) {
                 int serrno = errno;
-                LOG("Failed setting read-only attribute");
+                LOG("Failed setting read-only attribute: %s", strerror(serrno));
                 return -serrno;
             }
         } else {
             int serrno = errno;
-            LOG("Failed setting flags");
+            LOG("Failed setting flags: %s", strerror(serrno));
             return -serrno;
         }
     }
@@ -769,7 +769,7 @@ static ssize_t nbd_receive_request(int csock, struct nbd_request *request)
     }
 
     if (ret != sizeof(buf)) {
-        LOG("read failed");
+        LOG("partial read indicates failure: (%ld != %ld)", ret, sizeof(buf));
         return -EINVAL;
     }
 


### PR DESCRIPTION
...since the errno value is ultimately dropped.

In my case, it took much longer than it should have to figure out why I could not start a block device because no useful diagnostic information was available (not even the exit status). Having the strerror value would have helped.
