### PR TITLE
openrisc: terminate qemu process upon receiving a halt signal from the g...

### DIFF
--- a/target-openrisc/translate.c
+++ b/target-openrisc/translate.c
@@ -750,6 +750,9 @@ static void dec_misc(DisasContext *dc, uint32_t insn)
         switch (op1) {
         case 0x01:    /* l.nop */
             LOG_DIS("l.nop %d\n", I16);
+            /* Exit QEMU upon receiving l.nop 0xC instruction */
+            if(I16 == 0xC)
+                exit(0);
             break;
 
         default:


### PR DESCRIPTION
...uest program

or1ksim simulator currently handles l.nop 0xC instruction as a halt signal. Do the same for QEMU.