### PR TITLE
Fix address resolution issue with `-s` option

### DIFF
--- a/qemu-char.c
+++ b/qemu-char.c
@@ -3606,6 +3606,7 @@ static void qemu_chr_parse_socket(QemuOpts *opts, ChardevBackend *backend,
         addr->inet = g_new0(InetSocketAddress, 1);
         addr->inet->host = g_strdup(host);
         addr->inet->port = g_strdup(port);
+        addr->inet->has_port = true;
         addr->inet->has_to = qemu_opt_get(opts, "to");
         addr->inet->to = qemu_opt_get_number(opts, "to", 0);
         addr->inet->has_ipv4 = qemu_opt_get(opts, "ipv4");


### PR DESCRIPTION
In `qemu_chr_parse_socket`, `port` is copied to `addr`, but `has_port` is not set, so `port` isn't copied in future `qapi_copy_SocketAddress` calls. This results in an "address resolution failed for ::" message when using the `-s` option (or using `-gdb tcp::<port>`, i.e. not specifying a hostname).