### PR TITLE
Add new await_trans_vm_sig for ivshmem interop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ dummy := $(call unnest-vars,, \
                 stub-obj-y \
                 util-obj-y \
                 qga-obj-y \
+                await_trans_vm_sig-obj-y \
                 ivshmem-client-obj-y \
                 ivshmem-server-obj-y \
                 libvhost-user-obj-y \
@@ -344,6 +345,9 @@ ifneq ($(EXESUF),)
 .PHONY: qemu-ga
 qemu-ga: qemu-ga$(EXESUF) $(QGA_VSS_PROVIDER) $(QEMU_GA_MSI)
 endif
+
+await_trans_vm_sig$(EXESUF): $(await_trans_vm_sig-obj-y) libqemuutil.a libqemustub.a
+	$(call LINK, $^)
 
 ivshmem-client$(EXESUF): $(ivshmem-client-obj-y) libqemuutil.a libqemustub.a
 	$(call LINK, $^)

--- a/Makefile.objs
+++ b/Makefile.objs
@@ -113,6 +113,7 @@ qga-vss-dll-obj-y = qga/
 
 ######################################################################
 # contrib
+await_trans_vm_sig-obj-y = contrib/ivshmem-client/
 ivshmem-client-obj-y = contrib/ivshmem-client/
 ivshmem-server-obj-y = contrib/ivshmem-server/
 libvhost-user-obj-y = contrib/libvhost-user/

--- a/configure
+++ b/configure
@@ -4811,7 +4811,7 @@ if test "$want_tools" = "yes" ; then
   tools="qemu-img\$(EXESUF) qemu-io\$(EXESUF) $tools"
   if [ "$linux" = "yes" -o "$bsd" = "yes" -o "$solaris" = "yes" ] ; then
     tools="qemu-nbd\$(EXESUF) $tools"
-    tools="ivshmem-client\$(EXESUF) ivshmem-server\$(EXESUF) $tools"
+    tools="ivshmem-client\$(EXESUF) await_trans_vm_sig\$(EXESUF) ivshmem-server\$(EXESUF) $tools"
   fi
 fi
 if test "$softmmu" = yes ; then

--- a/contrib/ivshmem-client/Makefile.objs
+++ b/contrib/ivshmem-client/Makefile.objs
@@ -1,1 +1,2 @@
 ivshmem-client-obj-y = ivshmem-client.o main.o
+await_trans_vm_sig-obj-y = ivshmem-client.o await_trans_vm_sig.o

--- a/contrib/ivshmem-client/ivshmem-client.h
+++ b/contrib/ivshmem-client/ivshmem-client.h
@@ -209,4 +209,48 @@ ivshmem_client_search_peer(IvshmemClient *client, int64_t peer_id);
  */
 void ivshmem_client_dump(const IvshmemClient *client);
 
+#define IVSHMEM_CLIENT_DEFAULT_VERBOSE        0
+#define IVSHMEM_CLIENT_DEFAULT_UNIX_SOCK_PATH "/tmp/ivshmem_socket"
+
+typedef struct IvshmemClientArgs {
+    bool verbose;
+    const char *unix_sock_path;
+} IvshmemClientArgs;
+
+
+/* show ivshmem_client_usage and exit with given error code */
+void
+ivshmem_client_usage(const char *name, int code);
+
+/* parse the program arguments, exit on error */
+void
+ivshmem_client_parse_args(IvshmemClientArgs *args, int argc, char *argv[]);
+
+/* show command line help */
+void
+ivshmem_client_cmdline_help(void);
+
+/* read stdin and handle commands */
+int
+ivshmem_client_handle_stdin_command(IvshmemClient *client);
+
+/* handle message coming from server (new peer, new vectors) */
+int
+ivshmem_client_handle_server_msg(IvshmemClient *client);
+
+/* handle events from eventfd: just print a message on notification */
+int
+ivshmem_client_handle_event(IvshmemClient *client, const fd_set *cur, int maxfd);
+
+/* listen on stdin (command line), on unix socket (notifications of new
+ * and dead peers), and on eventfd (IRQ request) */
+int
+ivshmem_client_poll_events(IvshmemClient *client);
+
+/* callback when we receive a notification (just display it) */
+void
+ivshmem_client_notification_cb(const IvshmemClient *client,
+                               const IvshmemClientPeer *peer,
+                               unsigned vect, void *arg);
+
 #endif /* IVSHMEM_CLIENT_H */


### PR DESCRIPTION
+This host based utility is excellent for waiting to receive a signal
from within a connected QEMU instance.
+Some refactoring was done between the client object and the
client main in order to make some code more accessible and reusable


I need this in order to be able to run some tests between instances. It's not much overall, and it's probably useful to others, so I thought I would share it.