### PR TITLE
Swap SIGRTMIN + 1 and SIGRTMAX - 1

### DIFF
--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -75,8 +75,12 @@ static uint8_t host_to_target_signal_table[_NSIG] = {
     /* Nasty hack: Reverse SIGRTMIN and SIGRTMAX to avoid overlap with
        host libpthread signals.  This assumes no one actually uses SIGRTMAX :-/
        To fix this properly we need to do manual signal delivery multiplexed
-       over a single host signal.  */
+       over a single host signal.
+       Similarly we reverse SIGRTMIN + 1 and SIGRTMAX - 1, because
+       host glibc uses SIGRTMIN+1 for SIGSETXID. */
     [__SIGRTMIN] = __SIGRTMAX,
+    [__SIGRTMIN + 1] = __SIGRTMAX - 1,
+    [__SIGRTMAX - 1] = __SIGRTMIN + 1,
     [__SIGRTMAX] = __SIGRTMIN,
 };
 static uint8_t target_to_host_signal_table[_NSIG];


### PR DESCRIPTION
Let guest programs use SIGRTMIN + 1 by swapping with SIGRTMAX - 1.  Since QEMU links against glibc, it reserves the signal for itself and returns EINVAL (as noted in the commit message).  This means various applications that use SIGRTMIN + 1 cannot run on QEMU, including G-WAN web server and Open TFTP. 