### PR TITLE
linux-user: keep the name-ending parenthesis in /proc/self/stat

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -7305,7 +7305,10 @@ static int open_self_stat(void *cpu_env, int fd)
         snprintf(buf, sizeof(buf), "%"PRId64 " ", val);
       } else if (i == 1) {
         /* app name */
-        snprintf(buf, sizeof(buf), "(%s) ", ts->bprm->argv[0]);
+        len = snprintf(buf, sizeof(buf), "(%s) ", ts->bprm->argv[0]);
+        if (len >= sizeof(buf))
+          /* bring back the ending ") " that was truncated */
+          strcpy(buf+sizeof(buf)-3, ") ");
       } else if (i == 27) {
         /* stack bottom */
         val = start_stack;


### PR DESCRIPTION
When the program name is very long, qemu-user may truncate it in
/proc/self/stat. However the truncation must keep the ending ") "
to conform to the proc manpage which says:
    (2) comm  %s
           The  filename of the executable, in parentheses.  This
           is visible whether or not the  executable  is  swapped
           out.

To reproduce:
```
$ ln -s /bin/cat <filenamewithmorethan128chars>
$ qemu-x86_64 ./<filenamewithmorethan128chars> /proc/self/stat
```

Before the patch, you get:
`1134631 (<filenametruncated>0 0 0 0 0 0 0 0 ...`
After the patch:
`1134631 (<filenametruncat>) 0 0 0 0 0 0 0 0 ...`

This fixes an issue with hwloc failing to parse /proc/self/stat
when Ludovic Courtes was testing it in guix over qemu-aarch64.

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>