### PR TITLE
Add basic ebpf loader for steering rss.

### DIFF
--- a/ebpf/ebpf_rss.c
+++ b/ebpf/ebpf_rss.c
@@ -1,0 +1,140 @@
+#include <unistd.h>
+#include <bpf/libbpf.h>
+
+#include "ebpf/ebpf_rss.h"
+
+bool ebpf_rss_is_loaded(struct EBPFRSSContext *ctx)
+{
+    return ctx != NULL && ctx->program_fd >= 0;
+}
+
+bool ebpf_rss_load(struct EBPFRSSContext *ctx)
+{
+    int err = 0;
+    struct bpf_object *object = NULL;
+
+    if (ctx == NULL) {
+        return false;
+    }
+
+    /* TODO: remove hardcode - add proper elf path, like for seabios? */
+    err = bpf_prog_load("./rss.bpf.o", BPF_PROG_TYPE_SOCKET_FILTER,
+                        &object, &ctx->program_fd);
+    if (err) {
+        ctx->program_fd = -1;
+        return false;
+    }
+
+    ctx->map_configuration =
+            bpf_object__find_map_fd_by_name(object,
+            "tap_rss_map_configurations");
+    if (ctx->map_configuration < 0) {
+        goto map_issue;
+    }
+
+    ctx->map_toeplitz_key =
+            bpf_object__find_map_fd_by_name(object,
+            "tap_rss_map_toeplitz_key");
+    if (ctx->map_toeplitz_key < 0) {
+        goto map_issue;
+    }
+
+    ctx->map_indirections_table =
+            bpf_object__find_map_fd_by_name(object,
+            "tap_rss_map_indirection_table");
+    if (ctx->map_indirections_table < 0) {
+        goto map_issue;
+    }
+
+    return true;
+map_issue:
+    close(ctx->program_fd);
+    ctx->program_fd = -1;
+    return false;
+}
+
+bool ebpf_rss_set_config(struct EBPFRSSContext *ctx,
+                         struct EBPFRSSConfig *config)
+{
+    if (ctx == NULL || ctx->program_fd < 0) {
+        return false;
+    }
+
+    uint32_t map_key = 0;
+    if (bpf_map_update_elem(ctx->map_configuration,
+                            &map_key, config, BPF_ANY) < 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool ebpf_rss_set_inirection_table(struct EBPFRSSContext *ctx,
+                                   uint16_t *indirection_table, size_t len)
+{
+    if (ctx == NULL || ctx->program_fd < 0 ||
+       len > EBPF_RSS_INDIRECTION_TABLE_SIZE) {
+        return false;
+    }
+    uint32_t i = 0;
+
+    for (; i < len; ++i) {
+        if (bpf_map_update_elem(ctx->map_configuration, &i,
+                                indirection_table + i, BPF_ANY) < 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool ebpf_rss_set_toepliz_key(struct EBPFRSSContext *ctx, uint8_t *toeplitz_key)
+{
+    if (ctx == NULL || ctx->program_fd < 0) {
+        return false;
+    }
+
+    uint32_t map_key = 0;
+    if (bpf_map_update_elem(ctx->map_configuration, &map_key, toeplitz_key,
+                            BPF_ANY) < 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool ebpf_rss_set_all(struct EBPFRSSContext *ctx, struct EBPFRSSConfig *config,
+                      uint16_t *indirection_table, uint8_t *toeplitz_key)
+{
+    if (ctx == NULL || config == NULL || indirection_table == NULL ||
+       toeplitz_key == NULL || ctx->program_fd < 0) {
+        return false;
+    }
+
+    if (!ebpf_rss_set_config(ctx, config)) {
+        return false;
+    }
+
+    if (!ebpf_rss_set_inirection_table(ctx, indirection_table,
+                                      config->indirections_len)) {
+        return false;
+    }
+
+    if (!ebpf_rss_set_toepliz_key(ctx, toeplitz_key)) {
+        return false;
+    }
+
+    return true;
+}
+
+void ebpf_rss_unload(struct EBPFRSSContext *ctx)
+{
+    if (ctx == NULL || ctx->program_fd < 0) {
+        return;
+    }
+
+    close(ctx->program_fd);
+    close(ctx->map_configuration);
+    close(ctx->map_toeplitz_key);
+    close(ctx->map_indirections_table);
+}

--- a/ebpf/ebpf_rss.h
+++ b/ebpf/ebpf_rss.h
@@ -1,0 +1,41 @@
+#ifndef QEMU_EBPF_RSS_H
+#define QEMU_EBPF_RSS_H
+
+#include <bpf/bpf.h>
+
+#define EBPF_RSS_INDIRECTION_TABLE_SIZE 128
+
+struct EBPFRSSContext {
+    int program_fd;
+    int map_configuration;
+    int map_toeplitz_key;
+    int map_indirections_table;
+};
+
+struct EBPFRSSConfig {
+    uint8_t redirect;
+    uint8_t populate_hash;
+    uint32_t hash_types;
+    uint16_t indirections_len;
+    uint16_t default_queue;
+};
+
+bool ebpf_rss_is_loaded(struct EBPFRSSContext *ctx);
+
+bool ebpf_rss_load(struct EBPFRSSContext *ctx);
+
+bool ebpf_rss_set_config(struct EBPFRSSContext *ctx,
+                         struct EBPFRSSConfig *config);
+
+bool ebpf_rss_set_inirection_table(struct EBPFRSSContext *ctx,
+                                   uint16_t *indirection_table, size_t len);
+
+bool ebpf_rss_set_toepliz_key(struct EBPFRSSContext *ctx,
+                              uint8_t *toeplitz_key);
+
+bool ebpf_rss_set_all(struct EBPFRSSContext *ctx, struct EBPFRSSConfig *config,
+                      uint16_t *indirection_table, uint8_t *toeplitz_key);
+
+void ebpf_rss_unload(struct EBPFRSSContext *ctx);
+
+#endif /* QEMU_EBPF_RSS_H */

--- a/ebpf/meson.build
+++ b/ebpf/meson.build
@@ -1,0 +1,5 @@
+ebpf_ss = ss.source_set()
+
+ebpf_ss.add(files('ebpf_rss.c'))
+
+specific_ss.add_all(ebpf_ss)

--- a/include/hw/virtio/virtio-net.h
+++ b/include/hw/virtio/virtio-net.h
@@ -20,6 +20,8 @@
 #include "net/announce.h"
 #include "qemu/option_int.h"
 
+#include "ebpf/ebpf_rss.h"
+
 #define TYPE_VIRTIO_NET "virtio-net-device"
 #define VIRTIO_NET(obj) \
         OBJECT_CHECK(VirtIONet, (obj), TYPE_VIRTIO_NET)
@@ -215,6 +217,7 @@ struct VirtIONet {
     Notifier migration_state;
     VirtioNetRssData rss_data;
     struct NetRxPkt *rx_pkt;
+    struct EBPFRSSContext ebpf_rss;
 };
 
 void virtio_net_set_netclient_name(VirtIONet *n, const char *name,

--- a/include/net/net.h
+++ b/include/net/net.h
@@ -60,6 +60,7 @@ typedef int (SetVnetBE)(NetClientState *, bool);
 typedef struct SocketReadState SocketReadState;
 typedef void (SocketReadStateFinalize)(SocketReadState *rs);
 typedef void (NetAnnounce)(NetClientState *);
+typedef bool (SetStreeringEBPF)(NetClientState *, int);
 
 typedef struct NetClientInfo {
     NetClientDriver type;
@@ -81,6 +82,7 @@ typedef struct NetClientInfo {
     SetVnetLE *set_vnet_le;
     SetVnetBE *set_vnet_be;
     NetAnnounce *announce;
+    SetStreeringEBPF *set_steering_ebpf;
 } NetClientInfo;
 
 struct NetClientState {

--- a/meson.build
+++ b/meson.build
@@ -897,6 +897,7 @@ subdir('accel')
 subdir('plugins')
 subdir('bsd-user')
 subdir('linux-user')
+subdir('ebpf')
 
 bsd_user_ss.add(files('gdbstub.c'))
 specific_ss.add_all(when: 'CONFIG_BSD_USER', if_true: bsd_user_ss)
@@ -983,6 +984,8 @@ common_all = static_library('common',
                             name_suffix: 'fa')
 
 feature_to_c = find_program('scripts/feature_to_c.sh')
+
+libbpf = cc.find_library('bpf')
 
 emulators = []
 foreach target : target_dirs
@@ -1106,7 +1109,7 @@ foreach target : target_dirs
     emulators += executable(exe['name'], exe['sources'],
                install: true,
                c_args: c_args,
-               dependencies: arch_deps + deps + exe['dependencies'],
+               dependencies: arch_deps + deps + exe['dependencies'] + [libbpf],
                objects: lib.extract_all_objects(recursive: true),
                link_language: link_language,
                link_depends: [block_syms, qemu_syms] + exe.get('link_depends', []),


### PR DESCRIPTION
Loading ebpf program that used in tap for steering.
For now, it loads with virtio 'virtio_net_handle_rss()'.
So, in theory, two implementations of rss would work togather.
Added hacks to menson build - libbpf dependency and ebpf files.
In futuire, need to specify ebpf for linux only qemu.

Signed-off-by: Andrew Melnychenko <andrew@daynix.com>