### PR TITLE
Fix CDC-ECM and xHCI issues in hw/usb/dev-network.c

### DIFF
--- a/hw/usb/dev-network.c
+++ b/hw/usb/dev-network.c
@@ -1122,6 +1122,12 @@ static void usb_net_handle_control(USBDevice *dev, USBPacket *p,
 #endif
         break;
 
+    case ClassInterfaceOutRequest | USB_CDC_SET_ETHERNET_PACKET_FILTER:
+        if (is_rndis(s)) {
+            goto fail;
+        }
+        break;
+
     default:
     fail:
         fprintf(stderr, "usbnet: failed control transaction: "

--- a/hw/usb/dev-network.c
+++ b/hw/usb/dev-network.c
@@ -647,6 +647,7 @@ struct USBNetState {
     uint8_t in_buf[2048];
 
     USBEndpoint *intr;
+    USBEndpoint *bulk_in;
 
     char usbstring_mac[13];
     NICState *nic;
@@ -1317,6 +1318,7 @@ static ssize_t usbnet_receive(NetClientState *nc, const uint8_t *buf, size_t siz
     memcpy(in_buf, buf, size);
     s->in_len = total_size;
     s->in_ptr = 0;
+    usb_wakeup(s->bulk_in, 0);
     return size;
 }
 
@@ -1359,6 +1361,7 @@ static void usb_net_realize(USBDevice *dev, Error **errp)
     s->filter = 0;
     s->vendorid = 0x1234;
     s->intr = usb_ep_get(dev, USB_TOKEN_IN, 1);
+    s->bulk_in = usb_ep_get(dev, USB_TOKEN_IN, 2);
 
     qemu_macaddr_default_if_unset(&s->conf.macaddr);
     s->nic = qemu_new_nic(&net_usbnet_info, &s->conf,

--- a/hw/usb/dev-network.c
+++ b/hw/usb/dev-network.c
@@ -1211,7 +1211,7 @@ static void usb_net_handle_dataout(USBNetState *s, USBPacket *p)
     s->out_ptr += sz;
 
     if (!is_rndis(s)) {
-        if (p->iov.size < 64) {
+        if (p->iov.size % 64 || p->iov.size == 0) {
             qemu_send_packet(qemu_get_queue(s->nic), s->out_buf, s->out_ptr);
             s->out_ptr = 0;
         }


### PR DESCRIPTION
The emulated USB network device advertises support for operation as either RNDIS or CDC-ECM.  The CDC-ECM emulation is currently missing support for the mandatory SET_ETHERNET_PACKET_FILTER request, and does not report link status via the interrupt endpoint.

The wakeup and short packet detection logic is incompatible with the implementation of the emulated xHCI USB host controller.

This patch series address these issues.  With these patches, an OS that supports CDC-ECM (but not RNDIS) is able to use the emulated USB network device.