### PR TITLE
ide/core.c - ATA Version Support Bits are Incorrect

### DIFF
--- a/hw/ide/core.c
+++ b/hw/ide/core.c
@@ -165,7 +165,7 @@ static void ide_identify(IDEState *s)
         put_le16(p + 76, (1 << 8));
     }
 
-    put_le16(p + 80, 0xf0); /* ata3 -> ata6 supported */
+    put_le16(p + 80, ((1 << 6) | (1 << 5) (1 << 4) (1 << 3)); /* ata3 -> ata6 supported */
     put_le16(p + 81, 0x16); /* conforms to ata5 */
     /* 14=NOP supported, 5=WCACHE supported, 0=SMART supported */
     put_le16(p + 82, (1 << 14) | (1 << 5) | 1);


### PR DESCRIPTION
This field Major Version Number field is presently reporting support for ATA-4 through ATA-7.
Bitfield[80] is defined in the ATA-6 specification below.

0xF0 = (1<<7)  |  (1<<6)  |  (1 << 5) | (1 << 4) // 4-7 - current settings
0x78 = (1<<6)  |  (1<<5)  |  (1 << 4) | (1 << 3) // 3-6 - new settings

Either the comment is wrong, or the field is wrong.  If the field is wrong it can cause errors in drivers that check support vs conformity.  This will not break most guests, since the conformity field is set to ATA-5.

I'm not sure whether this component support ATA-7, but since it's commented as if it supports up through 6, correcting the field assignment seems more correct.

ATA/ATAPI-6 Specification
https://web.archive.org/web/20200124094822/https://www.t13.org/Documents/UploadedDocuments/project/d1410r3b-ATA-ATAPI-6.pdf

Page 116
80 - M Major version number
0000h or FFFFh = device does not report version
F 15 Reserved
F 14 Reserved for ATA/ATAPI-14
F 13 Reserved for ATA/ATAPI-13
F 12 Reserved for ATA/ATAPI-12
F 11 Reserved for ATA/ATAPI-11
F 10 Reserved for ATA/ATAPI-10
F 9 Reserved for ATA/ATAPI-9
F 8 Reserved for ATA/ATAPI-8
F 7 Reserved for ATA/ATAPI-7
F 6 1 = supports ATA/ATAPI-6
F 5 1 = supports ATA/ATAPI-5
F 4 1 = supports ATA/ATAPI-4
F 3 1 = supports ATA-3
X 2 Obsolete
X 1 Obsolete
F 0 Reserved