### PR TITLE
QUEUE_DEFAULT_SIZE: increase the values of VIRTIO_NET_RX_QUEUE_DEFAUL and  VIRTIO_NET_TX_QUEUE_DEFAULT_SIZE

### DIFF
--- a/hw/net/virtio-net.c
+++ b/hw/net/virtio-net.c
@@ -51,8 +51,8 @@
 #define MAX_VLAN    (1 << 12)   /* Per 802.1Q definition */
 
 /* previously fixed value */
-#define VIRTIO_NET_RX_QUEUE_DEFAULT_SIZE 256
-#define VIRTIO_NET_TX_QUEUE_DEFAULT_SIZE 256
+#define VIRTIO_NET_RX_QUEUE_DEFAULT_SIZE 1024
+#define VIRTIO_NET_TX_QUEUE_DEFAULT_SIZE 1024
 
 /* for now, only allow larger queues; with virtio-1, guest can downsize */
 #define VIRTIO_NET_RX_QUEUE_MIN_SIZE VIRTIO_NET_RX_QUEUE_DEFAULT_SIZE


### PR DESCRIPTION
Increasing the values of VIRTIO_NET_RX_QUEUE_DEFAULT_SIZE and VIRTIO_NET_TX_QUEUE_DEFAULT_SIZE will provide more data buffer space, thereby reducing the probability of packet loss

Signed-off-by: Zhongrui Tang <tangzhongrui_yewu@cmss.chinamobile.com>