### PR TITLE
hw/arm/aspeed: Added eMMC boot support for AST2600 image.

### DIFF
--- a/hw/arm/aspeed.c
+++ b/hw/arm/aspeed.c
@@ -148,7 +148,7 @@ struct AspeedMachineState {
         SCU_AST2400_HW_STRAP_BOOT_MODE(AST2400_SPI_BOOT))
 
 /* AST2600 evb hardware value */
-#define AST2600_EVB_HW_STRAP1 0x000000C0
+#define AST2600_EVB_HW_STRAP1 (0x000000C0 | AST26500_HW_STRAP_BOOT_SRC_EMMC)
 #define AST2600_EVB_HW_STRAP2 0x00000003
 
 /* Tacoma hardware value */


### PR DESCRIPTION
This patch has been added to boot eMMC image for AST2600 machine on
QEMU.

Run quemu as follows:

./qemu-system-arm -m 1G -M ast2600-evb -nographic -drive
file=mmc-evb-ast2600.img,format=raw,if=sd,index=2

Tested: Booted AST2600 eMMC image on QEMU.

Suggested-by: Troy Lee <leetroy@gmail.com>
Reviewed-by: Troy Lee <leetroy@gmail.com>
Reviewed-by: Andrew Jeffery <andrew@aj.id.au>
Signed-off-by: Shitalkumar Gandhi <shitalkumar.gandhi@seagate.com>