### PR TITLE
linux-user/mips64/target_elf.h: add loongson cpu e_flag abi detect

### DIFF
--- a/linux-user/mips64/target_elf.h
+++ b/linux-user/mips64/target_elf.h
@@ -15,6 +15,15 @@ static inline const char *cpu_get_model(uint32_t eflags)
     if ((eflags & EF_MIPS_MACH) == EF_MIPS_MACH_5900) {
         return "R5900";
     }
+    if ((eflags & EF_MIPS_MACH) == EF_MIPS_MACH_LS2E) {
+        return "Loongson-2E";
+    }
+    if ((eflags & EF_MIPS_MACH) == EF_MIPS_MACH_LS2F) {
+        return "Loongson-2F";
+    }
+    if ((eflags & EF_MIPS_MACH) == EF_MIPS_MACH_LS3A) {
+        return "Loongson-3A4000";
+    }
     return "5KEf";
 }
 #endif


### PR DESCRIPTION
add cpu: Loongson-2E,Loongson-2F,Loongson-3A4000

some elf e_flag[31:8] is not set, replace with shell command as below to test for 64bit arch
printf '\xa2' | dd conv=notrunc of=examplesh bs=1 seek=$((0x00000032)) #Loongson-3A4000

Signed-off-by: liubo <liubo@uniontech.com>