### PR TITLE
tests: fix jcc when gas using same register for %0 and %1

### DIFF
--- a/tests/tcg/i386/test-i386.c
+++ b/tests/tcg/i386/test-i386.c
@@ -356,8 +356,8 @@ void test_lea(void)
 #define TEST_JCC(JCC, v1, v2)\
 {\
     int res;\
-    asm("movl $1, %0\n\t"\
-        "cmpl %2, %1\n\t"\
+    asm ("cmpl %2, %1\n\t"\
+        "mov $1, %0\n\t"\
         "j" JCC " 1f\n\t"\
         "movl $0, %0\n\t"\
         "1:\n\t"\
@@ -365,8 +365,8 @@ void test_lea(void)
         : "r" (v1), "r" (v2));\
     printf("%-10s %d\n", "j" JCC, res);\
 \
-    asm("movl $0, %0\n\t"\
-        "cmpl %2, %1\n\t"\
+    asm ("cmpl %2, %1\n\t"\
+        "mov $0, %0\n\t"\
         "set" JCC " %b0\n\t"\
         : "=r" (res)\
         : "r" (v1), "r" (v2));\


### PR DESCRIPTION
The JCC test happening is not as expected to be:
For example v1 is in eax, and v2 is in edx.
But res is also in eax.
And it is being overwritten just before comparison.
Or for setCC the result is set to lower byte but ew bit register is being garbaged with v1 value.