### PR TITLE
Change bitwise OR to logical OR

### DIFF
--- a/hw/net/rocker/rocker_of_dpa.c
+++ b/hw/net/rocker/rocker_of_dpa.c
@@ -322,7 +322,7 @@ static void _of_dpa_flow_match(void *key, void *value, void *user_data)
     }
 
     for (i = 0; i < flow->key.width; i++, k++, m++, v++) {
-        if ((~*k & *m & *v) | (*k & *m & ~*v)) {
+        if ((~*k & *m & *v) || (*k & *m & ~*v)) {
             return;
         }
     }


### PR DESCRIPTION
My team and I were looking through the QEMU source code and found this line (325) that we think should be re-written to use a logical OR for improved readability and efficiency while retaining semantics.

Readability - simply evaluate binary states on either side of the expression rather than N-bit states
Efficiency - logical OR enables short circuiting in C