### PR TITLE
Freedesktop specification and Singular `keyword`

### DIFF
--- a/ui/qemu.desktop
+++ b/ui/qemu.desktop
@@ -4,5 +4,6 @@ Name=QEMU
 Icon=qemu
 Type=Application
 Terminal=false
-Keywords=Emulators;Virtualization;KVM;
+Keywords=Emulator;Virtualization;KVM;
+Categories=System;Emulator;
 NoDisplay=true


### PR DESCRIPTION
This file **is only usefull to menu systems** if it contains the `Categories` parameter.
1. Add. `Categories` parameter according with https://specifications.freedesktop.org/menu-spec/latest/apas02.html used by XFCE/Plasma/GNome and problably others
2. Incoherence btw. keywords: mixing plural and singular words. Changed to singular (correct)