### PR TITLE
tests/tcg/ppc64: Add mffsce test

### DIFF
--- a/tests/tcg/ppc64/Makefile.target
+++ b/tests/tcg/ppc64/Makefile.target
@@ -11,6 +11,7 @@ endif
 $(PPC64_TESTS): CFLAGS += -mpower8-vector
 
 PPC64_TESTS += mtfsf
+PPC64_TEST += mffsce
 
 ifneq ($(CROSS_CC_HAS_POWER10),)
 PPC64_TESTS += byte_reverse sha512-vector

--- a/tests/tcg/ppc64le/Makefile.target
+++ b/tests/tcg/ppc64le/Makefile.target
@@ -24,6 +24,7 @@ run-sha512-vector: QEMU_OPTS+=-cpu POWER10
 run-plugin-sha512-vector-with-%: QEMU_OPTS+=-cpu POWER10
 
 PPC64LE_TESTS += mtfsf
+PPC64LE_TESTS += mffsce
 PPC64LE_TESTS += signal_save_restore_xer
 PPC64LE_TESTS += xxspltw
 

--- a/tests/tcg/ppc64le/mffsce.c
+++ b/tests/tcg/ppc64le/mffsce.c
@@ -1,0 +1,54 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+
+#define MTFSF(FLM, FRB) asm volatile ("mtfsf %0, %1" :: "i" (FLM), "f" (FRB))
+#define MFFS(FRT) asm("mffs %0" : "=f" (FRT))
+#define MFFSCE(FRT) asm("mffsce %0" : "=f" (FRT))
+
+#define PPC_BIT_NR(nr) (63 - (nr))
+
+#define FP_VE (1ull << PPC_BIT_NR(56))
+#define FP_OE (1ull << PPC_BIT_NR(57))
+#define FP_UE (1ull << PPC_BIT_NR(58))
+#define FP_ZE (1ull << PPC_BIT_NR(59))
+#define FP_XE (1ull << PPC_BIT_NR(60))
+#define FP_NI (1ull << PPC_BIT_NR(61))
+#define FP_RN0 (1ull << PPC_BIT_NR(62))
+#define FP_RN1 (1ull << PPC_BIT_NR(63))
+
+int main(void)
+{
+    uint64_t frt, fpscr;
+    uint64_t last_8_bits = FP_VE | FP_UE | FP_ZE |
+                           FP_XE | FP_NI | FP_RN1;
+    MTFSF(0b11111111, last_8_bits); // set test value to cpu fpscr
+    MFFSCE(frt);
+    MFFS(fpscr);
+
+    // in the returned value
+    // should be as the cpu fpscr was before
+    assert((frt & FP_VE) != 0);
+    assert((frt & FP_OE) == 0);
+    assert((frt & FP_UE) != 0);
+    assert((frt & FP_ZE) != 0);
+    assert((frt & FP_XE) != 0);
+    assert((frt & FP_NI) != 0);
+    assert((frt & FP_RN0) == 0);
+    assert((frt & FP_RN1) != 0);
+
+    // in the cpu fpscr
+    // last 3 bits should be unchanged
+    assert((fpscr & FP_NI) != 0);
+    assert((fpscr & FP_RN0) == 0);
+    assert((fpscr & FP_RN1) != 0);
+
+    // enable bits should be unset
+    assert((fpscr & FP_VE) == 0);
+    assert((fpscr & FP_OE) == 0);
+    assert((fpscr & FP_UE) == 0);
+    assert((fpscr & FP_ZE) == 0);
+    assert((fpscr & FP_XE) == 0);
+
+    return 0;
+}


### PR DESCRIPTION
Add mffsce test to check both the return value and the new fpscr
stored in the cpu.

Signed-off-by: Víctor Colombo <victor.colombo@eldorado.org.br>

---

I though I had found a bug in mffsce while I was reading the code, but it wasn't the case
so, let's contribute the test I had to write as it is already done? :)