### PR TITLE
docs: microvm probably want -no-acpi

### DIFF
--- a/docs/system/i386/microvm.rst
+++ b/docs/system/i386/microvm.rst
@@ -75,7 +75,7 @@ legacy ``ISA serial`` device as console::
   $ qemu-system-x86_64 -M microvm \
      -enable-kvm -cpu host -m 512m -smp 2 \
      -kernel vmlinux -append "earlyprintk=ttyS0 console=ttyS0 root=/dev/vda" \
-     -nodefaults -no-user-config -nographic \
+     -no-acpi -nodefaults -no-user-config -nographic \
      -serial stdio \
      -drive id=test,file=test.img,format=raw,if=none \
      -device virtio-blk-device,drive=test \
@@ -97,7 +97,7 @@ disabled::
      -M microvm,x-option-roms=off,pit=off,pic=off,isa-serial=off,rtc=off \
      -enable-kvm -cpu host -m 512m -smp 2 \
      -kernel vmlinux -append "console=hvc0 root=/dev/vda" \
-     -nodefaults -no-user-config -nographic \
+     -no-acpi -nodefaults -no-user-config -nographic \
      -chardev stdio,id=virtiocon0 \
      -device virtio-serial-device \
      -device virtconsole,chardev=virtiocon0 \


### PR DESCRIPTION
if user is building a minimal kernel, they probably dont want acpi, but there's a gotcha that microvm doesn't announce devices then, unless you specify -no-acpi

i don't know if this maybe should be warning in the code itself, but in the meantime just adding -no-acpi in the docs helps avoid that

https://github.com/qemu/qemu/blob/75d30fde55485b965a1168a21d016dd07b50ed32/hw/i386/microvm.c#L476