### PR TITLE
virtio-dmabuf: introduce virtio-dmabuf

### DIFF
--- a/hw/display/meson.build
+++ b/hw/display/meson.build
@@ -37,6 +37,7 @@ softmmu_ss.add(when: 'CONFIG_MACFB', if_true: files('macfb.c'))
 softmmu_ss.add(when: 'CONFIG_NEXTCUBE', if_true: files('next-fb.c'))
 
 specific_ss.add(when: 'CONFIG_VGA', if_true: files('vga.c'))
+specific_ss.add(when: 'CONFIG_VIRTIO_GPU', if_true: files('virtio-dmabuf.c'))
 
 if (config_all_devices.has_key('CONFIG_VGA_CIRRUS') or
     config_all_devices.has_key('CONFIG_VGA_PCI') or

--- a/hw/display/virtio-dmabuf.c
+++ b/hw/display/virtio-dmabuf.c
@@ -1,0 +1,72 @@
+/*
+ * Virtio Shared dma-buf
+ *
+ * Copyright Red Hat, Inc. 2023
+ *
+ * Authors:
+ *     Albert Esteve <aesteve@redhat.com>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#include "hw/virtio/virtio-dmabuf.h"
+
+
+static struct shared_resources {
+    GHashTable *uuids;
+    bool locked;
+} res = {
+    .uuids = NULL,
+    .locked = false,
+};
+
+bool virtio_add_dmabuf(QemuUUID uuid, int udmabuf_fd)
+{
+    /*
+     * Check that the fd is valid.
+     */
+    return virtio_add_resource(uuid, GINT_TO_POINTER(udmabuf_fd));
+}
+
+bool virtio_add_resource(QemuUUID uuid, gpointer value)
+{
+    if (res.uuids == NULL) {
+        res.uuids = g_hash_table_new_full(NULL, NULL, NULL, g_free);
+    }
+    /*
+     * Add the resource to the table. If the key already exists in the table,
+     * do not replace its value and return false. Otherwise, return true.
+     */
+    return true;
+}
+
+bool virtio_remove_resource(QemuUUID uuid)
+{
+    if (res.uuids == NULL) {
+        return false;
+    }
+    /* 
+     * Remove the resource and return true if key was found and removed.
+     * If all resources are gone and table is empty, destroy the table.
+     */
+    return true;
+}
+
+int virtio_lookup_dmabuf(QemuUUID uuid)
+{
+    int fd = GPOINTER_TO_INT(virtio_lookup_resource(uuid));
+    if (!fd) {
+        return -1;
+    }
+    return fd;
+}
+
+gpointer virtio_lookup_resource(QemuUUID uuid)
+{
+    if (res.uuids == NULL) {
+        return (gpointer) NULL;
+    }
+    /* Lookup the resource in the table and return it (can be NULL). */
+    return (gpointer) NULL;
+}

--- a/include/hw/virtio/virtio-dmabuf.h
+++ b/include/hw/virtio/virtio-dmabuf.h
@@ -1,0 +1,28 @@
+/*
+ * Virtio Shared dma-buf
+ *
+ * Copyright Red Hat, Inc. 2023
+ *
+ * Authors:
+ *     Albert Esteve <aesteve@redhat.com>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
+ */
+
+#ifndef VIRTIO_DMABUF_H
+#define VIRTIO_DMABUF_H
+
+#include "qemu/osdep.h"
+
+#include <glib.h>
+#include "qemu/uuid.h"
+
+
+bool virtio_add_dmabuf(QemuUUID uuid, int dmabuf_fd);
+bool virtio_add_resource(QemuUUID uuid, gpointer value);
+bool virtio_remove_resource(QemuUUID uuid);
+int virtio_lookup_dmabuf(QemuUUID uuid);
+gpointer virtio_lookup_resource(QemuUUID uuid);
+
+#endif /* VIRTIO_DMABUF_H */

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -49,6 +49,7 @@ tests = {
   'test-qapi-util': [],
   'test-interval-tree': [],
   'test-xs-node': [qom],
+  'test-virtio-dmabuf': [meson.project_source_root() / 'hw/display/virtio-dmabuf.c'],
 }
 
 if have_system or have_tools

--- a/tests/unit/test-virtio-dmabuf.c
+++ b/tests/unit/test-virtio-dmabuf.c
@@ -1,0 +1,91 @@
+/*
+ * QEMU tests for shared dma-buf API
+ *
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "qemu/osdep.h"
+#include "hw/virtio/virtio-dmabuf.h"
+
+
+static void test_add_remove_resources(void)
+{
+    QemuUUID uuid;
+    int i, dmabuf_fd;
+
+    for (i = 0; i < 100; ++i) {
+        qemu_uuid_generate(&uuid);
+        dmabuf_fd = g_random_int_range(3, 500);
+        /* Add a new resource */
+        g_assert(virtio_add_dmabuf(uuid, dmabuf_fd));
+        g_assert(virtio_lookup_dmabuf(uuid) == dmabuf_fd);
+        /* Remove the resource */
+        g_assert(virtio_remove_resource(uuid));
+        /* Resource is not found anymore */
+        g_assert(virtio_lookup_dmabuf(uuid) == -1);
+    }
+}
+
+
+static void test_remove_invalid_resource(void)
+{
+    QemuUUID uuid;
+    int i;
+
+    for (i = 0; i < 20; ++i) {
+        qemu_uuid_generate(&uuid);
+        g_assert(virtio_lookup_dmabuf(uuid) == -1);
+        /* Removing a resource that does not exist returns false */
+        g_assert(virtio_remove_resource(uuid) == false);
+    }
+}
+
+static void test_add_invalid_resource(void)
+{
+    QemuUUID uuid;
+    int i, dmabuf_fd = -1;
+
+    for (i = 0; i < 20; ++i) {
+        qemu_uuid_generate(&uuid);
+        /* Add a new resource with invalid (negative) resource fd */
+        g_assert(virtio_add_dmabuf(uuid, dmabuf_fd) == false);
+        /* Rsource is not found */
+        g_assert(virtio_lookup_dmabuf(uuid) == -1);
+    }
+
+    for (i = 0; i < 20; ++i) {
+        /* Add a valid resource */
+        qemu_uuid_generate(&uuid);
+        dmabuf_fd = g_random_int_range(3, 500);
+        g_assert(virtio_add_dmabuf(uuid, dmabuf_fd));
+        g_assert(virtio_lookup_dmabuf(uuid) == dmabuf_fd);
+        /* Add a new resource with repeated uuid returns false */
+        g_assert(virtio_add_dmabuf(uuid, dmabuf_fd) == false);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/virtio-dmabuf/add_rm_res", test_add_remove_resources);
+    g_test_add_func("/virtio-dmabuf/rm_invalid_res",
+                    test_remove_invalid_resource);
+    g_test_add_func("/virtio-dmabuf/add_invalid_res",
+                    test_add_invalid_resource);
+
+    return g_test_run();
+}


### PR DESCRIPTION
This API manages objects (in this iteration,
dmabuf fds) that can be shared along different
virtio devices.

The API allows the different devices to add,
remove and/or retrieve the objects by simply
invoking the public functions that reside in the
virtio-dmabuf file.