### PR TITLE
Allow unix file for VNC Websocket

### DIFF
--- a/ui/vnc.c
+++ b/ui/vnc.c
@@ -3715,11 +3715,6 @@ static int vnc_display_get_address(const char *addrstr,
         addr->type = SOCKET_ADDRESS_TYPE_UNIX;
         addr->u.q_unix.path = g_strdup(addrstr + 5);
 
-        if (websocket) {
-            error_setg(errp, "UNIX sockets not supported with websock");
-            goto cleanup;
-        }
-
         if (to) {
             error_setg(errp, "Port range not support with UNIX socket");
             goto cleanup;


### PR DESCRIPTION
Hi! I've tested UNIX socket functionality for websocket and it works with noVNC. The configuration requires  reverse proxy for UNIX socket so it could be server as HTTP to end client. I did my test with simple nginx configuration.
