### PR TITLE
update event idx if guest has made extra available buffer during doub…

### DIFF
--- a/hw/net/virtio-net.c
+++ b/hw/net/virtio-net.c
@@ -1654,6 +1654,7 @@ static int virtio_net_has_buffers(VirtIONetQueue *q, int bufsize)
         if (virtio_queue_empty(q->rx_vq) ||
             (n->mergeable_rx_bufs &&
              !virtqueue_avail_bytes(q->rx_vq, bufsize, 0))) {
+            virtio_queue_set_notification(q->rx_vq, 1);
             return 0;
         }
     }


### PR DESCRIPTION
commit 06b12970174: "virtio-net: fix network stall under load" rechecks available buffers but not update event idx if buffers are still not enough.

Update event idx anyway.