### PR TITLE
Suggestion for an Instruction Mapping between QEMU RVI32/64 Translation and Sail Language

### DIFF
--- a/target/riscv/insn_trans/expanded_trans_rvi.c.inc
+++ b/target/riscv/insn_trans/expanded_trans_rvi.c.inc
@@ -1,0 +1,1541 @@
+/*
+ * RISC-V translation routines for the RVXI Base Integer Instruction Set.
+ *
+ * Copyright (c) 2016-2017 Sagar Karandikar, sagark@eecs.berkeley.edu
+ * Copyright (c) 2018 Peer Adelt, peer.adelt@hni.uni-paderborn.de
+ *                    Bastian Koppelmann, kbastian@mail.uni-paderborn.de
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 or later, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+static bool trans_illegal(DisasContext *ctx, arg_empty *a)
+{
+    TCGContext *s = tcg_ctx;
+    GHashTable *h = s->const_table[TCG_TYPE_I32];
+    TCGTemp *ts;
+
+    if (h == NULL) {
+        h = g_hash_table_new(g_int64_hash, g_int64_equal);
+        s->const_table[TCG_TYPE_I32] = h;
+    }
+
+    ts = g_hash_table_lookup(h, &ctx->opcode);
+    if (ts == NULL) {
+        int64_t *val_ptr;
+
+        ts = tcg_temp_alloc(s);
+
+        if (TCG_TARGET_REG_BITS == 32 && TCG_TYPE_I32 == TCG_TYPE_I64) {
+            TCGTemp *ts2 = tcg_temp_alloc(s);
+
+            tcg_debug_assert(ts2 == ts + 1);
+
+            ts->base_type = TCG_TYPE_I64;
+            ts->type = TCG_TYPE_I32;
+            ts->kind = TEMP_CONST;
+            ts->temp_allocated = 1;
+
+            ts2->base_type = TCG_TYPE_I64;
+            ts2->type = TCG_TYPE_I32;
+            ts2->kind = TEMP_CONST;
+            ts2->temp_allocated = 1;
+            ts2->temp_subindex = 1;
+
+            /*
+             * Retain the full value of the 64-bit constant in the low
+             * part, so that the hash table works.  Actual uses will
+             * truncate the value to the low part.
+             */
+            ts[HOST_BIG_ENDIAN].val = ctx->opcode;
+            ts[!HOST_BIG_ENDIAN].val = ctx->opcode >> 32;
+            val_ptr = &ts[HOST_BIG_ENDIAN].val;
+        } else {
+            ts->base_type = TCG_TYPE_I32;
+            ts->type = TCG_TYPE_I32;
+            ts->kind = TEMP_CONST;
+            ts->temp_allocated = 1;
+            ts->val = ctx->opcode;
+            val_ptr = &ts->val;
+        }
+        g_hash_table_insert(h, val_ptr, ts);
+    }
+    ptrdiff_t n = ts - tcg_ctx->temps;
+    assert(n >= 0 && n < tcg_ctx->nb_temps);
+    TCGOp *op = tcg_op_alloc(INDEX_op_st_i32, 3);
+
+    if (tcg_ctx->emit_before_op) {
+        QTAILQ_INSERT_BEFORE(tcg_ctx->emit_before_op, op, link);
+    } else {
+        QTAILQ_INSERT_TAIL(&tcg_ctx->ops, op, link);
+    }
+    op->args[0] = (TCGv_i32)((void *)ts - (void *)tcg_ctx);
+    op->args[1] = tcg_env;
+    op->args[2] = offsetof(CPURISCVState, bins);
+    if (ctx->virt_inst_excp) {
+        target_ulong dest = ctx->base.pc_next + 0;
+        assert(ctx->pc_save != -1);
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            tcg_gen_addi_tl(cpu_pc, cpu_pc, dest - ctx->pc_save);
+            if ((ctx)->xl == MXL_RV32) {
+                tcg_gen_ext32s_tl(cpu_pc, cpu_pc);
+            }
+        } else {
+            if ((ctx)->xl == MXL_RV32) {
+                dest = (int32_t)dest;
+            }
+            tcg_gen_movi_tl(cpu_pc, dest);
+        }
+        ctx->pc_save = ctx->base.pc_next + 0;
+        gen_helper_raise_exception(tcg_env, (TCGv_i32)((void *)RISCV_EXCP_VIRT_INSTRUCTION_FAULT - (void *)tcg_ctx));
+        ctx->base.is_jmp = DISAS_NORETURN;
+    } else {
+        target_ulong dest = ctx->base.pc_next + 0;
+        assert(ctx->pc_save != -1);
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            tcg_gen_addi_tl(cpu_pc, cpu_pc, dest - ctx->pc_save);
+            if ((ctx)->xl == MXL_RV32) {
+                tcg_gen_ext32s_tl(cpu_pc, cpu_pc);
+            }
+        } else {
+            if ((ctx)->xl == MXL_RV32) {
+                dest = (int32_t)dest;
+            }
+            tcg_gen_movi_tl(cpu_pc, dest);
+        }
+        ctx->pc_save = ctx->base.pc_next + 0;
+        gen_helper_raise_exception(tcg_env, (TCGv_i32)((void *)RISCV_EXCP_ILLEGAL_INST - (void *)tcg_ctx));
+        ctx->base.is_jmp = DISAS_NORETURN;
+        
+    }
+    return true;
+}
+
+static bool trans_c64_illegal(DisasContext *ctx, arg_empty *a)
+{
+    do {
+        if ((ctx)->xl == MXL_RV32) {
+            return false;
+        }
+    } while (0);
+    
+    TCGContext *s = tcg_ctx;
+    GHashTable *h = s->const_table[TCG_TYPE_I32];
+    TCGTemp *ts;
+
+    if (h == NULL) {
+        h = g_hash_table_new(g_int64_hash, g_int64_equal);
+        s->const_table[TCG_TYPE_I32] = h;
+    }
+
+    ts = g_hash_table_lookup(h, &ctx->opcode);
+    if (ts == NULL) {
+        int64_t *val_ptr;
+
+        ts = tcg_temp_alloc(s);
+
+        if (TCG_TARGET_REG_BITS == 32 && TCG_TYPE_I32 == TCG_TYPE_I64) {
+            TCGTemp *ts2 = tcg_temp_alloc(s);
+
+            tcg_debug_assert(ts2 == ts + 1);
+
+            ts->base_type = TCG_TYPE_I64;
+            ts->type = TCG_TYPE_I32;
+            ts->kind = TEMP_CONST;
+            ts->temp_allocated = 1;
+
+            ts2->base_type = TCG_TYPE_I64;
+            ts2->type = TCG_TYPE_I32;
+            ts2->kind = TEMP_CONST;
+            ts2->temp_allocated = 1;
+            ts2->temp_subindex = 1;
+
+            /*
+             * Retain the full value of the 64-bit constant in the low
+             * part, so that the hash table works.  Actual uses will
+             * truncate the value to the low part.
+             */
+            ts[HOST_BIG_ENDIAN].val = ctx->opcode;
+            ts[!HOST_BIG_ENDIAN].val = ctx->opcode >> 32;
+            val_ptr = &ts[HOST_BIG_ENDIAN].val;
+        } else {
+            ts->base_type = TCG_TYPE_I32;
+            ts->type = TCG_TYPE_I32;
+            ts->kind = TEMP_CONST;
+            ts->temp_allocated = 1;
+            ts->val = ctx->opcode;
+            val_ptr = &ts->val;
+        }
+        g_hash_table_insert(h, val_ptr, ts);
+    }
+    ptrdiff_t n = ts - tcg_ctx->temps;
+    assert(n >= 0 && n < tcg_ctx->nb_temps);
+    TCGOp *op = tcg_op_alloc(INDEX_op_st_i32, 3);
+
+    if (tcg_ctx->emit_before_op) {
+        QTAILQ_INSERT_BEFORE(tcg_ctx->emit_before_op, op, link);
+    } else {
+        QTAILQ_INSERT_TAIL(&tcg_ctx->ops, op, link);
+    }
+    op->args[0] = (TCGv_i32)((void *)ts - (void *)tcg_ctx);
+    op->args[1] = tcg_env;
+    op->args[2] = offsetof(CPURISCVState, bins);
+    if (ctx->virt_inst_excp) {
+        target_ulong dest = ctx->base.pc_next + 0;
+        assert(ctx->pc_save != -1);
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            tcg_gen_addi_tl(cpu_pc, cpu_pc, dest - ctx->pc_save);
+            if (get_xl(ctx) == MXL_RV32) {
+                tcg_gen_ext32s_tl(cpu_pc, cpu_pc);
+            }
+        } else {
+            if (get_xl(ctx) == MXL_RV32) {
+                dest = (int32_t)dest;
+            }
+            tcg_gen_movi_tl(cpu_pc, dest);
+        }
+        ctx->pc_save = ctx->base.pc_next + 0;
+        gen_helper_raise_exception(tcg_env, (TCGv_i32)((void *)RISCV_EXCP_VIRT_INSTRUCTION_FAULT - (void *)tcg_ctx));
+        ctx->base.is_jmp = DISAS_NORETURN;
+    } else {
+        target_ulong dest = ctx->base.pc_next + 0;
+        assert(ctx->pc_save != -1);
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            tcg_gen_addi_tl(cpu_pc, cpu_pc, dest - ctx->pc_save);
+            if (get_xl(ctx) == MXL_RV32) {
+                tcg_gen_ext32s_tl(cpu_pc, cpu_pc);
+            }
+        } else {
+            if (get_xl(ctx) == MXL_RV32) {
+                dest = (int32_t)dest;
+            }
+            tcg_gen_movi_tl(cpu_pc, dest);
+        }
+        ctx->pc_save = ctx->base.pc_next + 0;
+        gen_helper_raise_exception(tcg_env, (TCGv_i32)((void *)RISCV_EXCP_ILLEGAL_INST - (void *)tcg_ctx));
+        ctx->base.is_jmp = DISAS_NORETURN;
+        
+    }
+    return true;
+}
+
+static bool trans_lui(DisasContext *ctx, arg_lui *a)
+{
+    if (a->rd != 0) {
+        switch ((ctx)->ol) {
+        case MXL_RV32:
+            tcg_gen_movi_tl(cpu_gpr[a->rd], (int32_t)a->imm);
+            break;
+        case MXL_RV64:
+        case MXL_RV128:
+            tcg_gen_movi_tl(cpu_gpr[a->rd], a->imm);
+            break;
+        default:
+            g_assert_not_reached();
+        }
+
+        if ((ctx)->misa_mxl_max == MXL_RV128) {
+            tcg_gen_movi_tl(cpu_gprh[a->rd], -(a->imm < 0));
+        }
+    }
+    return true;
+}
+
+static TCGv dest_gpr(DisasContext *ctx, int reg_num)
+{
+    if (reg_num == 0 || get_olen(ctx) < TARGET_LONG_BITS) {
+        return tcg_temp_new();
+    }
+    return cpu_gpr[reg_num];
+}
+
+static bool trans_auipc(DisasContext *ctx, arg_auipc *a)
+{
+    TCGv target_pc;
+    if (a->rd == 0 || 16 << (ctx)->o < TARGET_LONG_BITS) {
+        target_pc = tcg_temp_new();
+    }
+    target_pc = cpu_gpr[a->rd];
+    target_ulong dest = ctx->base.pc_next + a->imm;
+
+    assert(ctx->pc_save != -1);
+    if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+        tcg_gen_addi_tl(target_pc, cpu_pc, dest - ctx->pc_save);
+        if ((ctx)->xl == MXL_RV32) {
+            tcg_gen_ext32s_tl(target_pc, target_pc);
+        }
+    } else {
+        if ((ctx)->xl == MXL_RV32) {
+            dest = (int32_t)dest;
+        }
+        tcg_gen_movi_tl(target_pc, dest);
+    }
+    if (a->rd != 0) {
+        switch ((ctx)->ol) {
+        case MXL_RV32:
+            tcg_gen_ext32s_tl(cpu_gpr[a->rd], target_pc);
+            break;
+        case MXL_RV64:
+        case MXL_RV128:
+            tcg_gen_mov_tl(cpu_gpr[a->rd], target_pc);
+            break;
+        default:
+            g_assert_not_reached();
+        }
+
+        if (get_xl_max(ctx) == MXL_RV128) {
+            tcg_gen_sari_tl(cpu_gprh[a->rd], cpu_gpr[a->rd], 63);
+        }
+    }
+    return true;
+}
+
+static void gen_jal(DisasContext *ctx, int rd, target_ulong imm)
+{
+    TCGv succ_pc = dest_gpr(ctx, rd);
+
+    /* check misaligned: */
+    if (!has_ext(ctx, RVC) && !ctx->cfg_ptr->ext_zca) {
+        if ((imm & 0x3) != 0) {
+            TCGv target_pc = tcg_temp_new();
+            gen_pc_plus_diff(target_pc, ctx, imm);
+            gen_exception_inst_addr_mis(ctx, target_pc);
+            return;
+        }
+    }
+
+    gen_pc_plus_diff(succ_pc, ctx, ctx->cur_insn_len);
+    gen_set_gpr(ctx, rd, succ_pc);
+
+    gen_goto_tb(ctx, 0, imm); /* must use this for safety */
+    ctx->base.is_jmp = DISAS_NORETURN;
+}
+
+void tcg_gen_mov_i32(TCGv_i32 ret, TCGv_i32 arg)
+{
+    if (ret != arg) {
+        tcg_gen_op2_i32(INDEX_op_mov_i32, ret, arg);
+    }
+}
+
+static bool trans_jal(DisasContext *ctx, arg_jal *a)
+{
+    TCGv succ_pc;
+    if (a->rd == 0 || 16 << (ctx)->ol < TARGET_LONG_BITS) {
+        succ_pc = tcg_temp_new();
+    }
+    succ_pc = cpu_gpr[a->rd];
+
+    /* check misaligned: */
+    if (!has_ext(ctx, RVC) && !ctx->cfg_ptr->ext_zca) {
+        if ((a->imm & 0x3) != 0) {
+            TCGv target_pc = tcg_temp_new();
+            target_ulong dest = ctx->base.pc_next + a->imm;
+            assert(ctx->pc_save != -1);
+            if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+                tcg_gen_addi_tl(target_pc, cpu_pc, dest - ctx->pc_save);
+                if ((ctx)->xl == MXL_RV32) {
+                    if (TCG_TARGET_REG_BITS == 32) {
+                        (void)temp_idx((void *)tcg_ctx + (uintptr_t)target_pc); /* trigger embedded assert */
+                        if ((TCGv_i32)((void *)(void *)tcg_ctx + (uintptr_t)target_pc - (void *)tcg_ctx) != (TCGv_i32)((void *)(void *)tcg_ctx + (uintptr_t)target_pc - (void *)tcg_ctx)) {
+                            TCGOp *op = tcg_op_alloc(INDEX_op_mov_i32, 2);
+                            if (tcg_ctx->emit_before_op) {
+                                QTAILQ_INSERT_BEFORE(tcg_ctx->emit_before_op, op, link);
+                            } else {
+                                QTAILQ_INSERT_TAIL(&tcg_ctx->ops, op, link);
+                            }
+                            op->args[0] = temp_arg(tcgv_i32_temp((TCGv_i32)((void *)(void *)tcg_ctx + (uintptr_t)target_pc + HOST_BIG_ENDIAN - (void *)tcg_ctx)));
+                            op->args[1] = temp_arg(tcgv_i32_temp((TCGv_i32)((void *)(void *)tcg_ctx + (uintptr_t)target_pc + HOST_BIG_ENDIAN - (void *)tcg_ctx)));
+                        }
+                        tcg_gen_sari_i32((TCGv_i32)((void *)(void *)tcg_ctx + (uintptr_t)target_pc + !HOST_BIG_ENDIAN - (void *)tcg_ctx), (TCGv_i32)((void *)(void *)tcg_ctx + (uintptr_t)target_pc - (void *)tcg_ctx), 31);
+                    } else if (TCG_TARGET_HAS_ext32s_i64) {
+                        tcg_gen_op2_i64(INDEX_op_ext32s_i64, target_pc, target_pc);
+                    } else {
+                        tcg_gen_shli_i64(target_pc, target_pc, 32);
+                        tcg_gen_sari_i64(target_pc, target_pc, 32);
+                    }
+                }
+            } else {
+                if ((ctx)->xl == MXL_RV32) {
+                    dest = (int32_t)dest;
+                }
+                tcg_gen_movi_tl(target_pc, dest);
+            }
+            gen_exception_inst_addr_mis(ctx, target_pc);
+            return;
+        }
+    }
+    target_ulong dest = ctx->base.pc_next + ctx->cur_insn_len;
+
+    assert(ctx->pc_save != -1);
+    if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+        tcg_gen_addi_tl(succ_pc, cpu_pc, dest - ctx->pc_save);
+        if (get_xl(ctx) == MXL_RV32) {
+            tcg_gen_ext32s_tl(succ_pc, succ_pc);
+        }
+    } else {
+        if (get_xl(ctx) == MXL_RV32) {
+            dest = (int32_t)dest;
+        }
+        tcg_gen_movi_tl(succ_pc, dest);
+    }
+    if (a->rd != 0) {
+        switch (get_ol(ctx)) {
+        case MXL_RV32:
+            tcg_gen_ext32s_tl(cpu_gpr[a->rd], succ_pc);
+            break;
+        case MXL_RV64:
+        case MXL_RV128:
+            tcg_gen_mov_tl(cpu_gpr[a->rd], succ_pc);
+            break;
+        default:
+            g_assert_not_reached();
+        }
+
+        if (get_xl_max(ctx) == MXL_RV128) {
+            tcg_gen_sari_tl(cpu_gprh[a->rd], cpu_gpr[a->rd], 63);
+        }
+    }
+
+    gen_goto_tb(ctx, 0, a->imm); /* must use this for safety */
+    ctx->base.is_jmp = DISAS_NORETURN;
+    TCGv succ_pc = dest_gpr(ctx, a->rd);
+
+    /* check misaligned: */
+    if (!has_ext(ctx, RVC) && !ctx->cfg_ptr->ext_zca) {
+        if ((a->imm & 0x3) != 0) {
+            TCGv target_pc = tcg_temp_new();
+            target_ulong dest = ctx->base.pc_next + a->imm;
+
+            assert(ctx->pc_save != -1);
+            if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+                tcg_gen_addi_tl(target_pc, cpu_pc, dest - ctx->pc_save);
+                if ((ctx)->xl == MXL_RV32) {
+                    tcg_gen_ext32s_tl(target_pc, target_pc);
+                }
+            } else {
+                if ((ctx)->xl == MXL_RV32) {
+                    dest = (int32_t)dest;
+                }
+                tcg_gen_movi_tl(target_pc, dest);
+            }
+            target_ulong dest = ctx->base.pc_next + a->imm;
+            assert(ctx->pc_save != -1);
+            if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+                tcg_gen_addi_tl(target_pc, cpu_pc, dest - ctx->pc_save);
+                if ((ctx)->xl == MXL_RV32) {
+                    tcg_gen_ext32s_tl(target_pc, target_pc);
+                }
+            } else {
+                if ((ctx)->xl == MXL_RV32) {
+                    dest = (int32_t)dest;
+                }
+                tcg_gen_movi_tl(target_pc, dest);
+            }
+            gen_exception_inst_addr_mis(ctx, target_pc);
+            return;
+        }
+    }
+
+    target_ulong dest = ctx->base.pc_next + ctx->cur_insn_len;
+    assert(ctx->pc_save != -1);
+    if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+        tcg_gen_addi_tl(succ_pc, cpu_pc, dest - ctx->pc_save);
+        if ((ctx)->xl== MXL_RV32) {
+            tcg_gen_ext32s_tl(succ_pc, succ_pc);
+        }
+    } else {
+        if ((ctx)->xl == MXL_RV32) {
+            dest = (int32_t)dest;
+        }
+        tcg_gen_movi_tl(succ_pc, dest);
+    }
+    if (a->rd != 0) {
+        switch (get_ol(ctx)) {
+        case MXL_RV32:
+            tcg_gen_ext32s_tl(cpu_gpr[a->rd], succ_pc);
+            break;
+        case MXL_RV64:
+        case MXL_RV128:
+            tcg_gen_mov_tl(cpu_gpr[a->rd], succ_pc);
+            break;
+        default:
+            g_assert_not_reached();
+        }
+
+        if ((ctx)->misa_mxl_max == MXL_RV128) {
+            tcg_gen_sari_tl(cpu_gprh[a->rd], cpu_gpr[a->rd], 63);
+        }
+    }
+    
+    target_ulong dest = ctx->base.pc_next + a->imm;
+
+     /*
+      * Under itrigger, instruction executes one by one like singlestep,
+      * direct block chain benefits will be small.
+      */
+    if (translator_use_goto_tb(&ctx->base, dest) && !ctx->itrigger) {
+        /*
+         * For pcrel, the pc must always be up-to-date on entry to
+         * the linked TB, so that it can use simple additions for all
+         * further adjustments.  For !pcrel, the linked TB is compiled
+         * to know its full virtual address, so we can delay the
+         * update to pc to the unlinked path.  A long chain of links
+         * can thus avoid many updates to the PC.
+         */
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            gen_update_pc(ctx, a->imm);
+            tcg_gen_goto_tb(0);
+        } else {
+            tcg_gen_goto_tb(0);
+            gen_update_pc(ctx, a->imm);
+        }
+        tcg_gen_exit_tb(ctx->base.tb, 0);
+    } else {
+        gen_update_pc(ctx, a->imm);
+        lookup_and_goto_ptr(ctx);
+    }
+    ctx->base.is_jmp = DISAS_NORETURN;
+    return true;
+}
+
+static bool trans_jalr(DisasContext *ctx, arg_jalr *a)
+{
+    TCGLabel *misaligned = NULL;
+    TCGv target_pc = tcg_temp_new();
+    TCGv succ_pc = dest_gpr(ctx, a->rd);
+
+    tcg_gen_addi_tl(target_pc, get_gpr(ctx, a->rs1, EXT_NONE), a->imm);
+    tcg_gen_andi_tl(target_pc, target_pc, (target_ulong)-2);
+
+    if (get_xl(ctx) == MXL_RV32) {
+        tcg_gen_ext32s_tl(target_pc, target_pc);
+    }
+
+    if (!has_ext(ctx, RVC) && !ctx->cfg_ptr->ext_zca) {
+        TCGv t0 = tcg_temp_new();
+
+        misaligned = gen_new_label();
+        tcg_gen_andi_tl(t0, target_pc, 0x2);
+        tcg_gen_brcondi_tl(TCG_COND_NE, t0, 0x0, misaligned);
+    }
+
+    gen_pc_plus_diff(succ_pc, ctx, ctx->cur_insn_len);
+    gen_set_gpr(ctx, a->rd, succ_pc);
+
+    tcg_gen_mov_tl(cpu_pc, target_pc);
+    lookup_and_goto_ptr(ctx);
+
+    if (misaligned) {
+        gen_set_label(misaligned);
+        gen_exception_inst_addr_mis(ctx, target_pc);
+    }
+    ctx->base.is_jmp = DISAS_NORETURN;
+
+    return true;
+}
+
+static TCGCond gen_compare_i128(bool bz, TCGv rl,
+                                TCGv al, TCGv ah, TCGv bl, TCGv bh,
+                                TCGCond cond)
+{
+    TCGv rh = tcg_temp_new();
+    bool invert = false;
+
+    switch (cond) {
+    case TCG_COND_EQ:
+    case TCG_COND_NE:
+        if (bz) {
+            tcg_gen_or_tl(rl, al, ah);
+        } else {
+            tcg_gen_xor_tl(rl, al, bl);
+            tcg_gen_xor_tl(rh, ah, bh);
+            tcg_gen_or_tl(rl, rl, rh);
+        }
+        break;
+
+    case TCG_COND_GE:
+    case TCG_COND_LT:
+        if (bz) {
+            tcg_gen_mov_tl(rl, ah);
+        } else {
+            TCGv tmp = tcg_temp_new();
+
+            tcg_gen_sub2_tl(rl, rh, al, ah, bl, bh);
+            tcg_gen_xor_tl(rl, rh, ah);
+            tcg_gen_xor_tl(tmp, ah, bh);
+            tcg_gen_and_tl(rl, rl, tmp);
+            tcg_gen_xor_tl(rl, rh, rl);
+        }
+        break;
+
+    case TCG_COND_LTU:
+        invert = true;
+        /* fallthrough */
+    case TCG_COND_GEU:
+        {
+            TCGv tmp = tcg_temp_new();
+            TCGv zero = tcg_constant_tl(0);
+            TCGv one = tcg_constant_tl(1);
+
+            cond = TCG_COND_NE;
+            /* borrow in to second word */
+            tcg_gen_setcond_tl(TCG_COND_LTU, tmp, al, bl);
+            /* seed third word with 1, which will be result */
+            tcg_gen_sub2_tl(tmp, rh, ah, one, tmp, zero);
+            tcg_gen_sub2_tl(tmp, rl, tmp, rh, bh, zero);
+        }
+        break;
+
+    default:
+        g_assert_not_reached();
+    }
+
+    if (invert) {
+        cond = tcg_invert_cond(cond);
+    }
+    return cond;
+}
+
+static void gen_setcond_i128(TCGv rl, TCGv rh,
+                             TCGv src1l, TCGv src1h,
+                             TCGv src2l, TCGv src2h,
+                             TCGCond cond)
+{
+    cond = gen_compare_i128(false, rl, src1l, src1h, src2l, src2h, cond);
+    tcg_gen_setcondi_tl(cond, rl, rl, 0);
+    tcg_gen_movi_tl(rh, 0);
+}
+
+static bool gen_branch(DisasContext *ctx, arg_b *a, TCGCond cond)
+{
+    TCGLabel *l = gen_new_label();
+    TCGv src1 = get_gpr(ctx, a->rs1, EXT_SIGN);
+    TCGv src2 = get_gpr(ctx, a->rs2, EXT_SIGN);
+    target_ulong orig_pc_save = ctx->pc_save;
+
+    if (get_xl(ctx) == MXL_RV128) {
+        TCGv src1h = get_gprh(ctx, a->rs1);
+        TCGv src2h = get_gprh(ctx, a->rs2);
+        TCGv tmp = tcg_temp_new();
+
+        cond = gen_compare_i128(a->rs2 == 0,
+                                tmp, src1, src1h, src2, src2h, cond);
+        tcg_gen_brcondi_tl(cond, tmp, 0, l);
+    } else {
+        tcg_gen_brcond_tl(cond, src1, src2, l);
+    }
+    gen_goto_tb(ctx, 1, ctx->cur_insn_len);
+    ctx->pc_save = orig_pc_save;
+
+    gen_set_label(l); /* branch taken */
+
+    if (!has_ext(ctx, RVC) && !ctx->cfg_ptr->ext_zca &&
+        (a->imm & 0x3)) {
+        /* misaligned */
+        TCGv target_pc = tcg_temp_new();
+        gen_pc_plus_diff(target_pc, ctx, a->imm);
+        gen_exception_inst_addr_mis(ctx, target_pc);
+    } else {
+        gen_goto_tb(ctx, 0, a->imm);
+    }
+    ctx->pc_save = -1;
+    ctx->base.is_jmp = DISAS_NORETURN;
+
+    return true;
+}
+
+static bool trans_beq(DisasContext *ctx, arg_beq *a)
+{
+    return gen_branch(ctx, a, TCG_COND_EQ);
+}
+
+static bool trans_bne(DisasContext *ctx, arg_bne *a)
+{
+    return gen_branch(ctx, a, TCG_COND_NE);
+}
+
+static bool trans_blt(DisasContext *ctx, arg_blt *a)
+{
+    return gen_branch(ctx, a, TCG_COND_LT);
+}
+
+static bool trans_bge(DisasContext *ctx, arg_bge *a)
+{
+    return gen_branch(ctx, a, TCG_COND_GE);
+}
+
+static bool trans_bltu(DisasContext *ctx, arg_bltu *a)
+{
+    return gen_branch(ctx, a, TCG_COND_LTU);
+}
+
+static bool trans_bgeu(DisasContext *ctx, arg_bgeu *a)
+{
+    return gen_branch(ctx, a, TCG_COND_GEU);
+}
+
+static bool gen_load_tl(DisasContext *ctx, arg_lb *a, MemOp memop)
+{
+    TCGv dest = dest_gpr(ctx, a->rd);
+    TCGv addr = get_address(ctx, a->rs1, a->imm);
+
+    tcg_gen_qemu_ld_tl(dest, addr, ctx->mem_idx, memop);
+    gen_set_gpr(ctx, a->rd, dest);
+    return true;
+}
+
+/* Compute only 64-bit addresses to use the address translation mechanism */
+static bool gen_load_i128(DisasContext *ctx, arg_lb *a, MemOp memop)
+{
+    TCGv src1l = get_gpr(ctx, a->rs1, EXT_NONE);
+    TCGv destl = dest_gpr(ctx, a->rd);
+    TCGv desth = dest_gprh(ctx, a->rd);
+    TCGv addrl = tcg_temp_new();
+
+    tcg_gen_addi_tl(addrl, src1l, a->imm);
+
+    if ((memop & MO_SIZE) <= MO_64) {
+        tcg_gen_qemu_ld_tl(destl, addrl, ctx->mem_idx, memop);
+        if (memop & MO_SIGN) {
+            tcg_gen_sari_tl(desth, destl, 63);
+        } else {
+            tcg_gen_movi_tl(desth, 0);
+        }
+    } else {
+        /* assume little-endian memory access for now */
+        tcg_gen_qemu_ld_tl(destl, addrl, ctx->mem_idx, MO_TEUQ);
+        tcg_gen_addi_tl(addrl, addrl, 8);
+        tcg_gen_qemu_ld_tl(desth, addrl, ctx->mem_idx, MO_TEUQ);
+    }
+
+    gen_set_gpr128(ctx, a->rd, destl, desth);
+    return true;
+}
+
+static bool gen_load(DisasContext *ctx, arg_lb *a, MemOp memop)
+{
+    bool out;
+
+    decode_save_opc(ctx);
+    if (get_xl(ctx) == MXL_RV128) {
+        out = gen_load_i128(ctx, a, memop);
+    } else {
+        out = gen_load_tl(ctx, a, memop);
+    }
+
+    if (ctx->ztso) {
+        tcg_gen_mb(TCG_MO_ALL | TCG_BAR_LDAQ);
+    }
+
+    return out;
+}
+
+static bool trans_lb(DisasContext *ctx, arg_lb *a)
+{
+    return gen_load(ctx, a, MO_SB);
+}
+
+static bool trans_lh(DisasContext *ctx, arg_lh *a)
+{
+    return gen_load(ctx, a, MO_TESW);
+}
+
+static bool trans_lw(DisasContext *ctx, arg_lw *a)
+{
+    return gen_load(ctx, a, MO_TESL);
+}
+
+static bool trans_ld(DisasContext *ctx, arg_ld *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    return gen_load(ctx, a, MO_TESQ);
+}
+
+static bool trans_lq(DisasContext *ctx, arg_lq *a)
+{
+    REQUIRE_128BIT(ctx);
+    return gen_load(ctx, a, MO_TEUO);
+}
+
+static bool trans_lbu(DisasContext *ctx, arg_lbu *a)
+{
+    return gen_load(ctx, a, MO_UB);
+}
+
+static bool trans_lhu(DisasContext *ctx, arg_lhu *a)
+{
+    return gen_load(ctx, a, MO_TEUW);
+}
+
+static bool trans_lwu(DisasContext *ctx, arg_lwu *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    return gen_load(ctx, a, MO_TEUL);
+}
+
+static bool trans_ldu(DisasContext *ctx, arg_ldu *a)
+{
+    REQUIRE_128BIT(ctx);
+    return gen_load(ctx, a, MO_TEUQ);
+}
+
+static bool gen_store_tl(DisasContext *ctx, arg_sb *a, MemOp memop)
+{
+    TCGv addr = get_address(ctx, a->rs1, a->imm);
+    TCGv data = get_gpr(ctx, a->rs2, EXT_NONE);
+
+    if (ctx->ztso) {
+        tcg_gen_mb(TCG_MO_ALL | TCG_BAR_STRL);
+    }
+
+    tcg_gen_qemu_st_tl(data, addr, ctx->mem_idx, memop);
+    return true;
+}
+
+static bool gen_store_i128(DisasContext *ctx, arg_sb *a, MemOp memop)
+{
+    TCGv src1l = get_gpr(ctx, a->rs1, EXT_NONE);
+    TCGv src2l = get_gpr(ctx, a->rs2, EXT_NONE);
+    TCGv src2h = get_gprh(ctx, a->rs2);
+    TCGv addrl = tcg_temp_new();
+
+    tcg_gen_addi_tl(addrl, src1l, a->imm);
+
+    if ((memop & MO_SIZE) <= MO_64) {
+        tcg_gen_qemu_st_tl(src2l, addrl, ctx->mem_idx, memop);
+    } else {
+        /* little-endian memory access assumed for now */
+        tcg_gen_qemu_st_tl(src2l, addrl, ctx->mem_idx, MO_TEUQ);
+        tcg_gen_addi_tl(addrl, addrl, 8);
+        tcg_gen_qemu_st_tl(src2h, addrl, ctx->mem_idx, MO_TEUQ);
+    }
+    return true;
+}
+
+static bool gen_store(DisasContext *ctx, arg_sb *a, MemOp memop)
+{
+    decode_save_opc(ctx);
+    if (get_xl(ctx) == MXL_RV128) {
+        return gen_store_i128(ctx, a, memop);
+    } else {
+        return gen_store_tl(ctx, a, memop);
+    }
+}
+
+static bool trans_sb(DisasContext *ctx, arg_sb *a)
+{
+    return gen_store(ctx, a, MO_SB);
+}
+
+static bool trans_sh(DisasContext *ctx, arg_sh *a)
+{
+    return gen_store(ctx, a, MO_TESW);
+}
+
+static bool trans_sw(DisasContext *ctx, arg_sw *a)
+{
+    return gen_store(ctx, a, MO_TESL);
+}
+
+static bool trans_sd(DisasContext *ctx, arg_sd *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    return gen_store(ctx, a, MO_TEUQ);
+}
+
+static bool trans_sq(DisasContext *ctx, arg_sq *a)
+{
+    REQUIRE_128BIT(ctx);
+    return gen_store(ctx, a, MO_TEUO);
+}
+
+static bool trans_addd(DisasContext *ctx, arg_addd *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_arith(ctx, a, EXT_NONE, tcg_gen_add_tl, NULL);
+}
+
+static bool trans_addid(DisasContext *ctx, arg_addid *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_arith_imm_fn(ctx, a, EXT_NONE, tcg_gen_addi_tl, NULL);
+}
+
+static bool trans_subd(DisasContext *ctx, arg_subd *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_arith(ctx, a, EXT_NONE, tcg_gen_sub_tl, NULL);
+}
+
+static void gen_addi2_i128(TCGv retl, TCGv reth,
+                           TCGv srcl, TCGv srch, target_long imm)
+{
+    TCGv imml  = tcg_constant_tl(imm);
+    TCGv immh  = tcg_constant_tl(-(imm < 0));
+    tcg_gen_add2_tl(retl, reth, srcl, srch, imml, immh);
+}
+
+static bool trans_addi(DisasContext *ctx, arg_addi *a)
+{
+    return gen_arith_imm_fn(ctx, a, EXT_NONE, tcg_gen_addi_tl, gen_addi2_i128);
+}
+
+static void gen_slt(TCGv ret, TCGv s1, TCGv s2)
+{
+    tcg_gen_setcond_tl(TCG_COND_LT, ret, s1, s2);
+}
+
+static void gen_slt_i128(TCGv retl, TCGv reth,
+                         TCGv s1l, TCGv s1h, TCGv s2l, TCGv s2h)
+{
+    gen_setcond_i128(retl, reth, s1l, s1h, s2l, s2h, TCG_COND_LT);
+}
+
+static void gen_sltu(TCGv ret, TCGv s1, TCGv s2)
+{
+    tcg_gen_setcond_tl(TCG_COND_LTU, ret, s1, s2);
+}
+
+static void gen_sltu_i128(TCGv retl, TCGv reth,
+                          TCGv s1l, TCGv s1h, TCGv s2l, TCGv s2h)
+{
+    gen_setcond_i128(retl, reth, s1l, s1h, s2l, s2h, TCG_COND_LTU);
+}
+
+static bool trans_slti(DisasContext *ctx, arg_slti *a)
+{
+    return gen_arith_imm_tl(ctx, a, EXT_SIGN, gen_slt, gen_slt_i128);
+}
+
+static bool trans_sltiu(DisasContext *ctx, arg_sltiu *a)
+{
+    return gen_arith_imm_tl(ctx, a, EXT_SIGN, gen_sltu, gen_sltu_i128);
+}
+
+static bool trans_xori(DisasContext *ctx, arg_xori *a)
+{
+    return gen_logic_imm_fn(ctx, a, tcg_gen_xori_tl);
+}
+
+static bool trans_ori(DisasContext *ctx, arg_ori *a)
+{
+    return gen_logic_imm_fn(ctx, a, tcg_gen_ori_tl);
+}
+
+static bool trans_andi(DisasContext *ctx, arg_andi *a)
+{
+    return gen_logic_imm_fn(ctx, a, tcg_gen_andi_tl);
+}
+
+static void gen_slli_i128(TCGv retl, TCGv reth,
+                          TCGv src1l, TCGv src1h,
+                          target_long shamt)
+{
+    if (shamt >= 64) {
+        tcg_gen_shli_tl(reth, src1l, shamt - 64);
+        tcg_gen_movi_tl(retl, 0);
+    } else {
+        tcg_gen_extract2_tl(reth, src1l, src1h, 64 - shamt);
+        tcg_gen_shli_tl(retl, src1l, shamt);
+    }
+}
+
+static bool trans_slli(DisasContext *ctx, arg_slli *a)
+{
+    return gen_shift_imm_fn(ctx, a, EXT_NONE, tcg_gen_shli_tl, gen_slli_i128);
+}
+
+static void gen_srliw(TCGv dst, TCGv src, target_long shamt)
+{
+    tcg_gen_extract_tl(dst, src, shamt, 32 - shamt);
+}
+
+static void gen_srli_i128(TCGv retl, TCGv reth,
+                          TCGv src1l, TCGv src1h,
+                          target_long shamt)
+{
+    if (shamt >= 64) {
+        tcg_gen_shri_tl(retl, src1h, shamt - 64);
+        tcg_gen_movi_tl(reth, 0);
+    } else {
+        tcg_gen_extract2_tl(retl, src1l, src1h, shamt);
+        tcg_gen_shri_tl(reth, src1h, shamt);
+    }
+}
+
+static bool trans_srli(DisasContext *ctx, arg_srli *a)
+{
+    return gen_shift_imm_fn_per_ol(ctx, a, EXT_NONE,
+                                   tcg_gen_shri_tl, gen_srliw, gen_srli_i128);
+}
+
+static void gen_sraiw(TCGv dst, TCGv src, target_long shamt)
+{
+    tcg_gen_sextract_tl(dst, src, shamt, 32 - shamt);
+}
+
+static void gen_srai_i128(TCGv retl, TCGv reth,
+                          TCGv src1l, TCGv src1h,
+                          target_long shamt)
+{
+    if (shamt >= 64) {
+        tcg_gen_sari_tl(retl, src1h, shamt - 64);
+        tcg_gen_sari_tl(reth, src1h, 63);
+    } else {
+        tcg_gen_extract2_tl(retl, src1l, src1h, shamt);
+        tcg_gen_sari_tl(reth, src1h, shamt);
+    }
+}
+
+static bool trans_srai(DisasContext *ctx, arg_srai *a)
+{
+    return gen_shift_imm_fn_per_ol(ctx, a, EXT_NONE,
+                                   tcg_gen_sari_tl, gen_sraiw, gen_srai_i128);
+}
+
+static bool trans_add(DisasContext *ctx, arg_add *a)
+{
+    return gen_arith(ctx, a, EXT_NONE, tcg_gen_add_tl, tcg_gen_add2_tl);
+}
+
+static bool trans_sub(DisasContext *ctx, arg_sub *a)
+{
+    return gen_arith(ctx, a, EXT_NONE, tcg_gen_sub_tl, tcg_gen_sub2_tl);
+}
+
+static void gen_sll_i128(TCGv destl, TCGv desth,
+                         TCGv src1l, TCGv src1h, TCGv shamt)
+{
+    TCGv ls = tcg_temp_new();
+    TCGv rs = tcg_temp_new();
+    TCGv hs = tcg_temp_new();
+    TCGv ll = tcg_temp_new();
+    TCGv lr = tcg_temp_new();
+    TCGv h0 = tcg_temp_new();
+    TCGv h1 = tcg_temp_new();
+    TCGv zero = tcg_constant_tl(0);
+
+    tcg_gen_andi_tl(hs, shamt, 64);
+    tcg_gen_andi_tl(ls, shamt, 63);
+    tcg_gen_neg_tl(shamt, shamt);
+    tcg_gen_andi_tl(rs, shamt, 63);
+
+    tcg_gen_shl_tl(ll, src1l, ls);
+    tcg_gen_shl_tl(h0, src1h, ls);
+    tcg_gen_shr_tl(lr, src1l, rs);
+    tcg_gen_movcond_tl(TCG_COND_NE, lr, shamt, zero, lr, zero);
+    tcg_gen_or_tl(h1, h0, lr);
+
+    tcg_gen_movcond_tl(TCG_COND_NE, destl, hs, zero, zero, ll);
+    tcg_gen_movcond_tl(TCG_COND_NE, desth, hs, zero, ll, h1);
+}
+
+static bool trans_sll(DisasContext *ctx, arg_sll *a)
+{
+    return gen_shift(ctx, a, EXT_NONE, tcg_gen_shl_tl, gen_sll_i128);
+}
+
+static bool trans_slt(DisasContext *ctx, arg_slt *a)
+{
+    return gen_arith(ctx, a, EXT_SIGN, gen_slt, gen_slt_i128);
+}
+
+static bool trans_sltu(DisasContext *ctx, arg_sltu *a)
+{
+    return gen_arith(ctx, a, EXT_SIGN, gen_sltu, gen_sltu_i128);
+}
+
+static void gen_srl_i128(TCGv destl, TCGv desth,
+                         TCGv src1l, TCGv src1h, TCGv shamt)
+{
+    TCGv ls = tcg_temp_new();
+    TCGv rs = tcg_temp_new();
+    TCGv hs = tcg_temp_new();
+    TCGv ll = tcg_temp_new();
+    TCGv lr = tcg_temp_new();
+    TCGv h0 = tcg_temp_new();
+    TCGv h1 = tcg_temp_new();
+    TCGv zero = tcg_constant_tl(0);
+
+    tcg_gen_andi_tl(hs, shamt, 64);
+    tcg_gen_andi_tl(rs, shamt, 63);
+    tcg_gen_neg_tl(shamt, shamt);
+    tcg_gen_andi_tl(ls, shamt, 63);
+
+    tcg_gen_shr_tl(lr, src1l, rs);
+    tcg_gen_shr_tl(h1, src1h, rs);
+    tcg_gen_shl_tl(ll, src1h, ls);
+    tcg_gen_movcond_tl(TCG_COND_NE, ll, shamt, zero, ll, zero);
+    tcg_gen_or_tl(h0, ll, lr);
+
+    tcg_gen_movcond_tl(TCG_COND_NE, destl, hs, zero, h1, h0);
+    tcg_gen_movcond_tl(TCG_COND_NE, desth, hs, zero, zero, h1);
+}
+
+static bool trans_srl(DisasContext *ctx, arg_srl *a)
+{
+    return gen_shift(ctx, a, EXT_ZERO, tcg_gen_shr_tl, gen_srl_i128);
+}
+
+static void gen_sra_i128(TCGv destl, TCGv desth,
+                         TCGv src1l, TCGv src1h, TCGv shamt)
+{
+    TCGv ls = tcg_temp_new();
+    TCGv rs = tcg_temp_new();
+    TCGv hs = tcg_temp_new();
+    TCGv ll = tcg_temp_new();
+    TCGv lr = tcg_temp_new();
+    TCGv h0 = tcg_temp_new();
+    TCGv h1 = tcg_temp_new();
+    TCGv zero = tcg_constant_tl(0);
+
+    tcg_gen_andi_tl(hs, shamt, 64);
+    tcg_gen_andi_tl(rs, shamt, 63);
+    tcg_gen_neg_tl(shamt, shamt);
+    tcg_gen_andi_tl(ls, shamt, 63);
+
+    tcg_gen_shr_tl(lr, src1l, rs);
+    tcg_gen_sar_tl(h1, src1h, rs);
+    tcg_gen_shl_tl(ll, src1h, ls);
+    tcg_gen_movcond_tl(TCG_COND_NE, ll, shamt, zero, ll, zero);
+    tcg_gen_or_tl(h0, ll, lr);
+    tcg_gen_sari_tl(lr, src1h, 63);
+
+    tcg_gen_movcond_tl(TCG_COND_NE, destl, hs, zero, h1, h0);
+    tcg_gen_movcond_tl(TCG_COND_NE, desth, hs, zero, lr, h1);
+}
+
+static bool trans_sra(DisasContext *ctx, arg_sra *a)
+{
+    return gen_shift(ctx, a, EXT_SIGN, tcg_gen_sar_tl, gen_sra_i128);
+}
+
+static bool trans_xor(DisasContext *ctx, arg_xor *a)
+{
+    return gen_logic(ctx, a, tcg_gen_xor_tl);
+}
+
+static bool trans_or(DisasContext *ctx, arg_or *a)
+{
+    return gen_logic(ctx, a, tcg_gen_or_tl);
+}
+
+static bool trans_and(DisasContext *ctx, arg_and *a)
+{
+    return gen_logic(ctx, a, tcg_gen_and_tl);
+}
+
+static bool trans_addiw(DisasContext *ctx, arg_addiw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_arith_imm_fn(ctx, a, EXT_NONE, tcg_gen_addi_tl, NULL);
+}
+
+static bool trans_slliw(DisasContext *ctx, arg_slliw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_shift_imm_fn(ctx, a, EXT_NONE, tcg_gen_shli_tl, NULL);
+}
+
+static bool trans_srliw(DisasContext *ctx, arg_srliw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_shift_imm_fn(ctx, a, EXT_NONE, gen_srliw, NULL);
+}
+
+static bool trans_sraiw(DisasContext *ctx, arg_sraiw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_shift_imm_fn(ctx, a, EXT_NONE, gen_sraiw, NULL);
+}
+
+static bool trans_sllid(DisasContext *ctx, arg_sllid *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_shift_imm_fn(ctx, a, EXT_NONE, tcg_gen_shli_tl, NULL);
+}
+
+static bool trans_srlid(DisasContext *ctx, arg_srlid *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_shift_imm_fn(ctx, a, EXT_NONE, tcg_gen_shri_tl, NULL);
+}
+
+static bool trans_sraid(DisasContext *ctx, arg_sraid *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_shift_imm_fn(ctx, a, EXT_NONE, tcg_gen_sari_tl,  NULL);
+}
+
+static bool trans_addw(DisasContext *ctx, arg_addw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_arith(ctx, a, EXT_NONE, tcg_gen_add_tl, NULL);
+}
+
+static bool trans_subw(DisasContext *ctx, arg_subw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_arith(ctx, a, EXT_NONE, tcg_gen_sub_tl, NULL);
+}
+
+static bool trans_sllw(DisasContext *ctx, arg_sllw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_shift(ctx, a, EXT_NONE, tcg_gen_shl_tl, NULL);
+}
+
+static bool trans_srlw(DisasContext *ctx, arg_srlw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_shift(ctx, a, EXT_ZERO, tcg_gen_shr_tl, NULL);
+}
+
+static bool trans_sraw(DisasContext *ctx, arg_sraw *a)
+{
+    REQUIRE_64_OR_128BIT(ctx);
+    ctx->ol = MXL_RV32;
+    return gen_shift(ctx, a, EXT_SIGN, tcg_gen_sar_tl, NULL);
+}
+
+static bool trans_slld(DisasContext *ctx, arg_slld *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_shift(ctx, a, EXT_NONE, tcg_gen_shl_tl, NULL);
+}
+
+static bool trans_srld(DisasContext *ctx, arg_srld *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_shift(ctx, a, EXT_ZERO, tcg_gen_shr_tl, NULL);
+}
+
+static bool trans_srad(DisasContext *ctx, arg_srad *a)
+{
+    REQUIRE_128BIT(ctx);
+    ctx->ol = MXL_RV64;
+    return gen_shift(ctx, a, EXT_SIGN, tcg_gen_sar_tl, NULL);
+}
+
+static bool trans_pause(DisasContext *ctx, arg_pause *a)
+{
+    if (!ctx->cfg_ptr->ext_zihintpause) {
+        return false;
+    }
+
+    /*
+     * PAUSE is a no-op in QEMU,
+     * end the TB and return to main loop
+     */
+    gen_update_pc(ctx, ctx->cur_insn_len);
+    exit_tb(ctx);
+    ctx->base.is_jmp = DISAS_NORETURN;
+
+    return true;
+}
+
+static bool trans_fence(DisasContext *ctx, arg_fence *a)
+{
+    /* FENCE is a full memory barrier. */
+    tcg_gen_mb(TCG_MO_ALL | TCG_BAR_SC);
+    return true;
+}
+
+static bool trans_fence_i(DisasContext *ctx, arg_fence_i *a)
+{
+    if (!ctx->cfg_ptr->ext_zifencei) {
+        return false;
+    }
+
+    /*
+     * FENCE_I is a no-op in QEMU,
+     * however we need to end the translation block
+     */
+    gen_update_pc(ctx, ctx->cur_insn_len);
+    exit_tb(ctx);
+    ctx->base.is_jmp = DISAS_NORETURN;
+    return true;
+}
+
+static bool do_csr_post(DisasContext *ctx)
+{
+    /* The helper may raise ILLEGAL_INSN -- record binv for unwind. */
+    decode_save_opc(ctx);
+    /* We may have changed important cpu state -- exit to main loop. */
+    gen_update_pc(ctx, ctx->cur_insn_len);
+    exit_tb(ctx);
+    ctx->base.is_jmp = DISAS_NORETURN;
+    return true;
+}
+
+static bool do_csrr(DisasContext *ctx, int rd, int rc)
+{
+    TCGv dest = dest_gpr(ctx, rd);
+    TCGv_i32 csr = tcg_constant_i32(rc);
+
+    translator_io_start(&ctx->base);
+    gen_helper_csrr(dest, tcg_env, csr);
+    gen_set_gpr(ctx, rd, dest);
+    return do_csr_post(ctx);
+}
+
+static bool do_csrw(DisasContext *ctx, int rc, TCGv src)
+{
+    TCGv_i32 csr = tcg_constant_i32(rc);
+
+    translator_io_start(&ctx->base);
+    gen_helper_csrw(tcg_env, csr, src);
+    return do_csr_post(ctx);
+}
+
+static bool do_csrrw(DisasContext *ctx, int rd, int rc, TCGv src, TCGv mask)
+{
+    TCGv dest = dest_gpr(ctx, rd);
+    TCGv_i32 csr = tcg_constant_i32(rc);
+
+    translator_io_start(&ctx->base);
+    gen_helper_csrrw(dest, tcg_env, csr, src, mask);
+    gen_set_gpr(ctx, rd, dest);
+    return do_csr_post(ctx);
+}
+
+static bool do_csrr_i128(DisasContext *ctx, int rd, int rc)
+{
+    TCGv destl = dest_gpr(ctx, rd);
+    TCGv desth = dest_gprh(ctx, rd);
+    TCGv_i32 csr = tcg_constant_i32(rc);
+
+    translator_io_start(&ctx->base);
+    gen_helper_csrr_i128(destl, tcg_env, csr);
+    tcg_gen_ld_tl(desth, tcg_env, offsetof(CPURISCVState, retxh));
+    gen_set_gpr128(ctx, rd, destl, desth);
+    return do_csr_post(ctx);
+}
+
+static bool do_csrw_i128(DisasContext *ctx, int rc, TCGv srcl, TCGv srch)
+{
+    TCGv_i32 csr = tcg_constant_i32(rc);
+
+    translator_io_start(&ctx->base);
+    gen_helper_csrw_i128(tcg_env, csr, srcl, srch);
+    return do_csr_post(ctx);
+}
+
+static bool do_csrrw_i128(DisasContext *ctx, int rd, int rc,
+                          TCGv srcl, TCGv srch, TCGv maskl, TCGv maskh)
+{
+    TCGv destl = dest_gpr(ctx, rd);
+    TCGv desth = dest_gprh(ctx, rd);
+    TCGv_i32 csr = tcg_constant_i32(rc);
+
+    translator_io_start(&ctx->base);
+    gen_helper_csrrw_i128(destl, tcg_env, csr, srcl, srch, maskl, maskh);
+    tcg_gen_ld_tl(desth, tcg_env, offsetof(CPURISCVState, retxh));
+    gen_set_gpr128(ctx, rd, destl, desth);
+    return do_csr_post(ctx);
+}
+
+static bool trans_csrrw(DisasContext *ctx, arg_csrrw *a)
+{
+    RISCVMXL xl = get_xl(ctx);
+    if (xl < MXL_RV128) {
+        TCGv src = get_gpr(ctx, a->rs1, EXT_NONE);
+
+        /*
+         * If rd == 0, the insn shall not read the csr, nor cause any of the
+         * side effects that might occur on a csr read.
+         */
+        if (a->rd == 0) {
+            return do_csrw(ctx, a->csr, src);
+        }
+
+        TCGv mask = tcg_constant_tl(xl == MXL_RV32 ? UINT32_MAX :
+                                                     (target_ulong)-1);
+        return do_csrrw(ctx, a->rd, a->csr, src, mask);
+    } else {
+        TCGv srcl = get_gpr(ctx, a->rs1, EXT_NONE);
+        TCGv srch = get_gprh(ctx, a->rs1);
+
+        /*
+         * If rd == 0, the insn shall not read the csr, nor cause any of the
+         * side effects that might occur on a csr read.
+         */
+        if (a->rd == 0) {
+            return do_csrw_i128(ctx, a->csr, srcl, srch);
+        }
+
+        TCGv mask = tcg_constant_tl(-1);
+        return do_csrrw_i128(ctx, a->rd, a->csr, srcl, srch, mask, mask);
+    }
+}
+
+static bool trans_csrrs(DisasContext *ctx, arg_csrrs *a)
+{
+    /*
+     * If rs1 == 0, the insn shall not write to the csr at all, nor
+     * cause any of the side effects that might occur on a csr write.
+     * Note that if rs1 specifies a register other than x0, holding
+     * a zero value, the instruction will still attempt to write the
+     * unmodified value back to the csr and will cause side effects.
+     */
+    if (get_xl(ctx) < MXL_RV128) {
+        if (a->rs1 == 0) {
+            return do_csrr(ctx, a->rd, a->csr);
+        }
+
+        TCGv ones = tcg_constant_tl(-1);
+        TCGv mask = get_gpr(ctx, a->rs1, EXT_ZERO);
+        return do_csrrw(ctx, a->rd, a->csr, ones, mask);
+    } else {
+        if (a->rs1 == 0) {
+            return do_csrr_i128(ctx, a->rd, a->csr);
+        }
+
+        TCGv ones = tcg_constant_tl(-1);
+        TCGv maskl = get_gpr(ctx, a->rs1, EXT_ZERO);
+        TCGv maskh = get_gprh(ctx, a->rs1);
+        return do_csrrw_i128(ctx, a->rd, a->csr, ones, ones, maskl, maskh);
+    }
+}
+
+static bool trans_csrrc(DisasContext *ctx, arg_csrrc *a)
+{
+    /*
+     * If rs1 == 0, the insn shall not write to the csr at all, nor
+     * cause any of the side effects that might occur on a csr write.
+     * Note that if rs1 specifies a register other than x0, holding
+     * a zero value, the instruction will still attempt to write the
+     * unmodified value back to the csr and will cause side effects.
+     */
+    if (get_xl(ctx) < MXL_RV128) {
+        if (a->rs1 == 0) {
+            return do_csrr(ctx, a->rd, a->csr);
+        }
+
+        TCGv mask = get_gpr(ctx, a->rs1, EXT_ZERO);
+        return do_csrrw(ctx, a->rd, a->csr, ctx->zero, mask);
+    } else {
+        if (a->rs1 == 0) {
+            return do_csrr_i128(ctx, a->rd, a->csr);
+        }
+
+        TCGv maskl = get_gpr(ctx, a->rs1, EXT_ZERO);
+        TCGv maskh = get_gprh(ctx, a->rs1);
+        return do_csrrw_i128(ctx, a->rd, a->csr,
+                             ctx->zero, ctx->zero, maskl, maskh);
+    }
+}
+
+static bool trans_csrrwi(DisasContext *ctx, arg_csrrwi *a)
+{
+    RISCVMXL xl = get_xl(ctx);
+    if (xl < MXL_RV128) {
+        TCGv src = tcg_constant_tl(a->rs1);
+
+        /*
+         * If rd == 0, the insn shall not read the csr, nor cause any of the
+         * side effects that might occur on a csr read.
+         */
+        if (a->rd == 0) {
+            return do_csrw(ctx, a->csr, src);
+        }
+
+        TCGv mask = tcg_constant_tl(xl == MXL_RV32 ? UINT32_MAX :
+                                                     (target_ulong)-1);
+        return do_csrrw(ctx, a->rd, a->csr, src, mask);
+    } else {
+        TCGv src = tcg_constant_tl(a->rs1);
+
+        /*
+         * If rd == 0, the insn shall not read the csr, nor cause any of the
+         * side effects that might occur on a csr read.
+         */
+        if (a->rd == 0) {
+            return do_csrw_i128(ctx, a->csr, src, ctx->zero);
+        }
+
+        TCGv mask = tcg_constant_tl(-1);
+        return do_csrrw_i128(ctx, a->rd, a->csr, src, ctx->zero, mask, mask);
+    }
+}
+
+static bool trans_csrrsi(DisasContext *ctx, arg_csrrsi *a)
+{
+    /*
+     * If rs1 == 0, the insn shall not write to the csr at all, nor
+     * cause any of the side effects that might occur on a csr write.
+     * Note that if rs1 specifies a register other than x0, holding
+     * a zero value, the instruction will still attempt to write the
+     * unmodified value back to the csr and will cause side effects.
+     */
+    if (get_xl(ctx) < MXL_RV128) {
+        if (a->rs1 == 0) {
+            return do_csrr(ctx, a->rd, a->csr);
+        }
+
+        TCGv ones = tcg_constant_tl(-1);
+        TCGv mask = tcg_constant_tl(a->rs1);
+        return do_csrrw(ctx, a->rd, a->csr, ones, mask);
+    } else {
+        if (a->rs1 == 0) {
+            return do_csrr_i128(ctx, a->rd, a->csr);
+        }
+
+        TCGv ones = tcg_constant_tl(-1);
+        TCGv mask = tcg_constant_tl(a->rs1);
+        return do_csrrw_i128(ctx, a->rd, a->csr, ones, ones, mask, ctx->zero);
+    }
+}
+
+static bool trans_csrrci(DisasContext *ctx, arg_csrrci * a)
+{
+    /*
+     * If rs1 == 0, the insn shall not write to the csr at all, nor
+     * cause any of the side effects that might occur on a csr write.
+     * Note that if rs1 specifies a register other than x0, holding
+     * a zero value, the instruction will still attempt to write the
+     * unmodified value back to the csr and will cause side effects.
+     */
+    if (get_xl(ctx) < MXL_RV128) {
+        if (a->rs1 == 0) {
+            return do_csrr(ctx, a->rd, a->csr);
+        }
+
+        TCGv mask = tcg_constant_tl(a->rs1);
+        return do_csrrw(ctx, a->rd, a->csr, ctx->zero, mask);
+    } else {
+        if (a->rs1 == 0) {
+            return do_csrr_i128(ctx, a->rd, a->csr);
+        }
+
+        TCGv mask = tcg_constant_tl(a->rs1);
+        return do_csrrw_i128(ctx, a->rd, a->csr,
+                             ctx->zero, ctx->zero, mask, ctx->zero);
+    }
+}

--- a/target/riscv/insn_trans/expanded_trans_rvi.c.inc
+++ b/target/riscv/insn_trans/expanded_trans_rvi.c.inc
@@ -250,14 +250,6 @@ static bool trans_lui(DisasContext *ctx, arg_lui *a)
     return true;
 }
 
-static TCGv dest_gpr(DisasContext *ctx, int reg_num)
-{
-    if (reg_num == 0 || get_olen(ctx) < TARGET_LONG_BITS) {
-        return tcg_temp_new();
-    }
-    return cpu_gpr[reg_num];
-}
-
 static bool trans_auipc(DisasContext *ctx, arg_auipc *a)
 {
     TCGv target_pc;
@@ -318,13 +310,6 @@ static void gen_jal(DisasContext *ctx, int rd, target_ulong imm)
 
     gen_goto_tb(ctx, 0, imm); /* must use this for safety */
     ctx->base.is_jmp = DISAS_NORETURN;
-}
-
-void tcg_gen_mov_i32(TCGv_i32 ret, TCGv_i32 arg)
-{
-    if (ret != arg) {
-        tcg_gen_op2_i32(INDEX_op_mov_i32, ret, arg);
-    }
 }
 
 static bool trans_jal(DisasContext *ctx, arg_jal *a)
@@ -406,7 +391,132 @@ static bool trans_jal(DisasContext *ctx, arg_jal *a)
         }
     }
 
-    gen_goto_tb(ctx, 0, a->imm); /* must use this for safety */
+    /* must use this for safety */
+    target_ulong dest = ctx->base.pc_next + a->imm;
+
+     /*
+      * Under itrigger, instruction executes one by one like singlestep,
+      * direct block chain benefits will be small.
+      */
+    if (translator_use_goto_tb(&ctx->base, dest) && !ctx->itrigger) {
+        /*
+         * For pcrel, the pc must always be up-to-date on entry to
+         * the linked TB, so that it can use simple additions for all
+         * further adjustments.  For !pcrel, the linked TB is compiled
+         * to know its full virtual address, so we can delay the
+         * update to pc to the unlinked path.  A long chain of links
+         * can thus avoid many updates to the PC.
+         */
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            gen_update_pc(ctx, a->imm);
+            /* We tested CF_NO_GOTO_TB in translator_use_goto_tb. */
+            tcg_debug_assert(!(tcg_ctx->gen_tb->cflags & CF_NO_GOTO_TB));
+            /* We only support two chained exits.  */
+            tcg_debug_assert(0 <= TB_EXIT_IDXMAX);
+#ifdef CONFIG_DEBUG_TCG
+            /* Verify that we haven't seen this numbered exit before.  */
+            tcg_debug_assert((tcg_ctx->goto_tb_issue_mask & (1 << idx)) == 0);
+            tcg_ctx->goto_tb_issue_mask |= 1 << idx;
+#endif
+            plugin_gen_disable_mem_helpers();
+            TCGOp *op = tcg_op_alloc(INDEX_op_goto_tb, 1);
+            if (tcg_ctx->emit_before_op) {
+                QTAILQ_INSERT_BEFORE(tcg_ctx->emit_before_op, op, link);
+            } else {
+                QTAILQ_INSERT_TAIL(&tcg_ctx->ops, op, link);
+            }
+            op->args[0] = 0;
+        } else {
+            /* We tested CF_NO_GOTO_TB in translator_use_goto_tb. */
+            tcg_debug_assert(!(tcg_ctx->gen_tb->cflags & CF_NO_GOTO_TB));
+            /* We only support two chained exits.  */
+            tcg_debug_assert(0 <= TB_EXIT_IDXMAX);
+#ifdef CONFIG_DEBUG_TCG
+            /* Verify that we haven't seen this numbered exit before.  */
+            tcg_debug_assert((tcg_ctx->goto_tb_issue_mask & (1 << idx)) == 0);
+            tcg_ctx->goto_tb_issue_mask |= 1 << idx;
+#endif
+            plugin_gen_disable_mem_helpers();
+            TCGOp *op = tcg_op_alloc(INDEX_op_goto_tb, 1);
+            if (tcg_ctx->emit_before_op) {
+                QTAILQ_INSERT_BEFORE(tcg_ctx->emit_before_op, op, link);
+            } else {
+                QTAILQ_INSERT_TAIL(&tcg_ctx->ops, op, link);
+            }
+            op->args[0] = 0;
+            target_ulong dest = ctx->base.pc_next + a->imm;
+            assert(ctx->pc_save != -1);
+            if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+                tcg_gen_addi_tl(cpu_pc, cpu_pc, dest - ctx->pc_save);
+                if (get_xl(ctx) == MXL_RV32) {
+                    tcg_gen_ext32s_tl(cpu_pc, cpu_pc);
+                }
+            } else {
+                if (get_xl(ctx) == MXL_RV32) {
+                    dest = (int32_t)dest;
+                }
+                tcg_gen_movi_tl(cpu_pc, dest);
+            }
+            ctx->pc_save = ctx->base.pc_next + a->imm;
+        }
+        tcg_gen_exit_tb(ctx->base.tb, 0);
+    } else {
+        target_ulong dest = ctx->base.pc_next + a->imm;
+        assert(ctx->pc_save != -1);
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            tcg_gen_addi_tl(cpu_pc, cpu_pc, dest - ctx->pc_save);
+            if (get_xl(ctx) == MXL_RV32) {
+                tcg_gen_ext32s_tl(cpu_pc, cpu_pc);
+            }
+        } else {
+            if (get_xl(ctx) == MXL_RV32) {
+                dest = (int32_t)dest;
+            }
+            tcg_gen_movi_tl(cpu_pc, dest);
+        }
+        ctx->pc_save = ctx->base.pc_next + a->imm;
+    #ifndef CONFIG_USER_ONLY
+        if (ctx->itrigger) {
+            gen_helper_itrigger_match(tcg_env);
+        }
+    #endif
+        TCGv_ptr ptr;
+
+        if (tcg_ctx->gen_tb->cflags & CF_NO_GOTO_PTR) {
+            tcg_gen_exit_tb(NULL, 0);
+            return;
+        }
+
+        if (tcg_ctx->plugin_insn) {
+            tcg_gen_plugin_cb(PLUGIN_GEN_AFTER_TB);
+        }
+        ptr = tcg_temp_ebb_new_ptr();
+        gen_helper_lookup_tb_ptr(ptr, tcg_env);
+        tcg_gen_op1i(INDEX_op_goto_ptr, tcgv_ptr_arg(ptr));
+        TCGTEMP* i32_temp = NULL;
+        uintptr_t o = (uintptr_t)ptr - offsetof(TCGContext, temps);
+
+        assert(o < sizeof(TCGTemp) * tcg_ctx->nb_temps);
+        assert(o % sizeof(TCGTemp) == 0);
+
+        *i32_temp = (void *)tcg_ctx + (uintptr_t)ptr;
+        TCGContext *s = tcg_ctx;
+
+        switch (i32_temp->kind) {
+        case TEMP_CONST:
+        case TEMP_TB:
+            /* Silently ignore free. */
+            break;
+        case TEMP_EBB:
+            tcg_debug_assert(i32_temp->temp_allocated != 0);
+            ts->temp_allocated = 0;
+            set_bit(temp_idx(i32_temp), s->free_temps[i32_temp->base_type].l);
+            break;
+        default:
+            /* It never made sense to free TEMP_FIXED or TEMP_GLOBAL. */
+            g_assert_not_reached();
+        }
+    }
     ctx->base.is_jmp = DISAS_NORETURN;
     TCGv succ_pc = dest_gpr(ctx, a->rd);
 
@@ -479,11 +589,20 @@ static bool trans_jal(DisasContext *ctx, arg_jal *a)
     
     target_ulong dest = ctx->base.pc_next + a->imm;
 
-     /*
-      * Under itrigger, instruction executes one by one like singlestep,
-      * direct block chain benefits will be small.
-      */
-    if (translator_use_goto_tb(&ctx->base, dest) && !ctx->itrigger) {
+    /*
+    * Under itrigger, instruction executes one by one like singlestep,
+    * direct block chain benefits will be small.
+    */
+    /* Suppress goto_tb if requested. */
+    bool cflags = false;
+    if (tb_cflags(&ctx->base->dest) & CF_NO_GOTO_TB) {
+        cflags = false;
+    } else {
+        cflags = true;
+    }
+    /* Check for the dest on the same page as the start of the TB.  */
+    return ((db->pc_first ^ dest) & TARGET_PAGE_MASK) == 0;
+    if (cflags && !ctx->itrigger) {
         /*
          * For pcrel, the pc must always be up-to-date on entry to
          * the linked TB, so that it can use simple additions for all
@@ -512,9 +631,36 @@ static bool trans_jalr(DisasContext *ctx, arg_jalr *a)
 {
     TCGLabel *misaligned = NULL;
     TCGv target_pc = tcg_temp_new();
-    TCGv succ_pc = dest_gpr(ctx, a->rd);
-
-    tcg_gen_addi_tl(target_pc, get_gpr(ctx, a->rs1, EXT_NONE), a->imm);
+    TCGv succ_pc;
+    if (reg_num == 0 || get_olen(ctx) < TARGET_LONG_BITS) {
+        succ_pc = tcg_temp_new();
+    } else {
+        succ_pc = cpu_gpr[a->rd];
+    }
+    /* some cases can be optimized here */
+    if (arg2 == 0) {
+        tcg_gen_mov_i64(target_pc, get_gpr(ctx, a->rs1, EXT_NONE));
+    } else if (TCG_TARGET_REG_BITS == 64) {
+        if (TCG_TARGET_REG_BITS == 64) {
+            tcg_gen_op3_i64(INDEX_op_add_i64, target_pc, get_gpr(ctx, a->rs1, EXT_NONE), tcg_constant_i64(a->imm));
+        } else {
+            tcg_gen_add2_i32(TCGV_LOW(target_pc), TCGV_HIGH(target_pc), TCGV_LOW(get_gpr(ctx, a->rs1, EXT_NONE)),
+                            TCGV_HIGH(get_gpr(ctx, a->rs1, EXT_NONE)), TCGV_LOW(tcg_constant_i64(a->imm)), TCGV_HIGH(tcg_constant_i64(a->imm)));
+        }
+    } else {
+        if (TCG_TARGET_HAS_add2_i32) {
+            tcg_gen_op6_i32(INDEX_op_add2_i32, TCGV_LOW(target_pc), TCGV_HIGH(target_pc), TCGV_LOW(get_gpr(ctx, a->rs1, EXT_NONE)), TCGV_HIGH(get_gpr(ctx, a->rs1, EXT_NONE)), tcg_constant_i32(a->imm), tcg_constant_i32(a->imm >> 32));
+        } else {
+            TCGv_i64 t0 = tcg_temp_ebb_new_i64();
+            TCGv_i64 t1 = tcg_temp_ebb_new_i64();
+            tcg_gen_concat_i32_i64(t0, TCGV_LOW(get_gpr(ctx, a->rs1, EXT_NONE)), TCGV_LOW(get_gpr(ctx, a->rs1, EXT_NONE)));
+            tcg_gen_concat_i32_i64(t1, tcg_constant_i32(a->imm), tcg_constant_i32(a->imm >> 32));
+            tcg_gen_add_i64(t0, t0, t1);
+            tcg_gen_extr_i64_i32(TCGV_LOW(target_pc), TCGV_HIGH(target_pc), t0);
+            tcg_temp_free_i64(t0);
+            tcg_temp_free_i64(t1);
+        }
+    }
     tcg_gen_andi_tl(target_pc, target_pc, (target_ulong)-2);
 
     if (get_xl(ctx) == MXL_RV32) {
@@ -529,15 +675,180 @@ static bool trans_jalr(DisasContext *ctx, arg_jalr *a)
         tcg_gen_brcondi_tl(TCG_COND_NE, t0, 0x0, misaligned);
     }
 
-    gen_pc_plus_diff(succ_pc, ctx, ctx->cur_insn_len);
-    gen_set_gpr(ctx, a->rd, succ_pc);
+    target_ulong dest = ctx->base.pc_next + ctx->cur_insn_len;
+    assert(ctx->pc_save != -1);
+    if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+        tcg_gen_addi_tl(succ_pc, cpu_pc, dest - ctx->pc_save);
+        if (get_xl(ctx) == MXL_RV32) {
+            tcg_gen_ext32s_tl(succ_pc, succ_pc);
+        }
+    } else {
+        if ((ctx)->xl == MXL_RV32) {
+            dest = (int32_t)dest;
+        }
+        tcg_gen_movi_tl(succ_pc, dest);
+    }
+    if (a->rd != 0) {
+        switch (get_ol(ctx)) {
+        case MXL_RV32:
+            tcg_gen_ext32s_tl(cpu_gpr[a->rd], succ_pc);
+            break;
+        case MXL_RV64:
+        case MXL_RV128:
+            tcg_gen_mov_tl(cpu_gpr[a->rd], succ_pc);
+            break;
+        default:
+            g_assert_not_reached();
+        }
+
+        if ((ctx)->misa_mxl_max == MXL_RV128) {
+            tcg_gen_sari_tl(cpu_gprh[a->rd], cpu_gpr[a->rd], 63);
+        }
+    }
 
     tcg_gen_mov_tl(cpu_pc, target_pc);
-    lookup_and_goto_ptr(ctx);
+    #ifndef CONFIG_USER_ONLY
+    if (ctx->itrigger) {
+        gen_helper_itrigger_match(tcg_env);
+    }
+    #endif
+        tcg_gen_lookup_and_goto_ptr();
+    }
+
+    static void exit_tb(DisasContext *ctx)
+    {
+    #ifndef CONFIG_USER_ONLY
+        if (ctx->itrigger) {
+            gen_helper_itrigger_match(tcg_env);
+        }
+    #endif
+        /*
+        * Let the jit code return the read-only version of the
+        * TranslationBlock, so that we minimize the pc-relative
+        * distance of the address of the exit_tb code to TB.
+        * This will improve utilization of pc-relative address loads.
+        *
+        * TODO: Move this to translator_loop, so that all const
+        * TranslationBlock pointers refer to read-only memory.
+        * This requires coordination with targets that do not use
+        * the translator_loop.
+        */
+#ifdef CONFIG_DEBUG_TCG
+        uintptr_t val = 0;
+        if ((void *)NULL) {
+            g_assert((size_t)((void *)NULL - region.start_aligned) <= region.total_size);
+            (void *)NULL += tcg_splitwx_diff;
+        }
+        val = (uintptr_t)(void *)NULL;
+
+        if (NULL) {
+            do { assert(0); } while (0);
+        } else if (0 <= TB_EXIT_IDXMAX) {
+#ifdef CONFIG_DEBUG_TCG
+            /* This is an exit following a goto_tb.  Verify that we have
+            seen this numbered exit before, via tcg_gen_goto_tb.  */
+            do { assert(tcg_ctx->goto_tb_issue_mask & (1 << idx)); } while (0);
+    #endif
+        } else {
+            /* This is an exit via the exitreq label.  */
+            do { assert(0 == TB_EXIT_REQUESTED); } while (0);
+        }
+
+        TCGOp *op = tcg_op_alloc(INDEX_op_exit_tb, 1);
+
+        if (tcg_ctx->emit_before_op) {
+            QTAILQ_INSERT_BEFORE(tcg_ctx->emit_before_op, op, link);
+        } else {
+            QTAILQ_INSERT_TAIL(&tcg_ctx->ops, op, link);
+        }
+        op->args[0] = val;
 
     if (misaligned) {
-        gen_set_label(misaligned);
-        gen_exception_inst_addr_mis(ctx, target_pc);
+        l->present = 1;
+        TCGOp *op = tcg_op_alloc(INDEX_op_set_label, 1);
+        if (tcg_ctx->emit_before_op) {
+            QTAILQ_INSERT_BEFORE(tcg_ctx->emit_before_op, op, link);
+        } else {
+            QTAILQ_INSERT_TAIL(&tcg_ctx->ops, op, link);
+        }
+        op->args[0] = (uintptr_t)misaligned;
+        tcg_gen_st_tl(target_pc, tcg_env, offsetof(CPURISCVState, badaddr));
+        target_ulong dest = ctx->base.pc_next + 0;
+        assert(ctx->pc_save != -1);
+        if (tb_cflags(ctx->base.tb) & CF_PCREL) {
+            tcg_gen_addi_tl(cpu_pc, cpu_pc, dest - ctx->pc_save);
+            if ((ctx)->xl == MXL_RV32) {
+                tcg_gen_ext32s_tl(cpu_pc, cpu_pc);
+            }
+        } else {
+            if ((ctx)->xl == MXL_RV32) {
+                dest = (int32_t)dest;
+            }
+            tcg_gen_movi_tl(cpu_pc, dest);
+        }
+        ctx->pc_save = ctx->base.pc_next + 0;
+        TCGContext *s = TCG_TYPE_I32;
+        GHashTable *h = s->const_table[TCG_TYPE_I32];
+        TCGTemp *ts;
+
+        if (h == NULL) {
+            h = g_hash_table_new(g_int64_hash, g_int64_equal);
+            s->const_table[TCG_TYPE_I32] = h;
+        }
+
+        ts = g_hash_table_lookup(h, &RISCV_EXCP_INST_ADDR_MIS);
+        if (ts == NULL) {
+            int64_t *val_ptr;
+
+            int n = s->nb_temps++;
+            if (n >= TCG_MAX_TEMPS) {
+                 siglongjmp(s->jmp_trans, -2);
+            } else {
+                ts = memset(&s->temps[n], 0, sizeof(TCGTemp));
+            }
+
+            if (TCG_TARGET_REG_BITS == 32 && TCG_TYPE_I32 == TCG_TYPE_I64) {
+                int n = s->nb_temps++;
+                if (n >= TCG_MAX_TEMPS) {
+                    siglongjmp(s->jmp_trans, -2);
+                } else {
+                    *ts2 = memset(&s->temps[n], 0, sizeof(TCGTemp));
+                }
+
+                tcg_debug_assert(ts2 == ts + 1);
+
+                ts->base_type = TCG_TYPE_I64;
+                ts->type = TCG_TYPE_I32;
+                ts->kind = TEMP_CONST;
+                ts->temp_allocated = 1;
+
+                ts2->base_type = TCG_TYPE_I64;
+                ts2->type = TCG_TYPE_I32;
+                ts2->kind = TEMP_CONST;
+                ts2->temp_allocated = 1;
+                ts2->temp_subindex = 1;
+
+                /*
+                * Retain the full value of the 64-bit constant in the low
+                * part, so that the hash table works.  Actual uses will
+                * truncate the value to the low part.
+                */
+                ts[HOST_BIG_ENDIAN].val = RISCV_EXCP_INST_ADDR_MIS;
+                ts[!HOST_BIG_ENDIAN].val = RISCV_EXCP_INST_ADDR_MIS >> 32;
+                val_ptr = &ts[HOST_BIG_ENDIAN].val;
+            } else {
+                ts->base_type = tcg_env;
+                ts->type = TCG_TYPE_I32;
+                ts->kind = TEMP_CONST;
+                ts->temp_allocated = 1;
+                ts->val = RISCV_EXCP_INST_ADDR_MIS;
+                val_ptr = &ts->RISCV_EXCP_INST_ADDR_MIS;
+            }
+            g_hash_table_insert(h, val_ptr, ts);
+        } 
+        (void)temp_idx(ts);
+        gen_helper_raise_exception(tcg_env, (TCGv_i32)((void *)ts - (void *)tcg_ctx));
+        ctx->base.is_jmp = DISAS_NORETURN;  
     }
     ctx->base.is_jmp = DISAS_NORETURN;
 

--- a/target/riscv/mapping/instruction_mapping.c
+++ b/target/riscv/mapping/instruction_mapping.c
@@ -1,0 +1,410 @@
+/*
+ * RISC-V emulation for qemu: Instruction mapping for Sail Instruction Emulation and Qemu
+ *
+ * Copyright (c) 2024 Vedant Tewari, vtewari@uwm.edu
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 or later, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "instruction_mapping.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+void to_uppercase(char* str) {
+	for (; *str; ++str) *str = toupper(*str);
+}
+
+void to_lowercase(char* str) {
+	for (; *str; ++str) *str = tolower(*str);
+}
+
+char* read_file(const char* filename) {
+		FILE* file = fopen(filename, "r");
+		if (!file) {
+				fprintf(stderr, "Could not open file %s\n", filename);
+				return NULL;
+		}
+
+		fseek(file, 0, SEEK_END);
+		long length = ftell(file);
+		fseek(file, 0, SEEK_SET);
+
+		char* content = (char*)malloc(length + 1);
+		if (!content) {
+				fprintf(stderr, "Could not allocate memory for file content\n");
+				fclose(file);
+				return NULL;
+		}
+
+		fread(content, 1, length, file);
+		content[length] = '\0';
+
+		fclose(file);
+		return content;
+}
+
+char* extract_sail_function(const char* content, const char* keyword) {
+		char* uppercase_keyword = strdup(keyword);
+		if (!uppercase_keyword) {
+				fprintf(stderr, "Could not allocate memory for uppercase conversion\n");
+				return NULL;
+		}
+		to_uppercase(uppercase_keyword);
+
+		char* start = strstr(content, "function clause execute");
+		while (start) {
+				char* end = strstr(start, "RETIRE_SUCCESS");
+				if (end) {
+						end += strlen("RETIRE_SUCCESS");
+						size_t length = end - start;
+						char* function = (char*)malloc(length + 1);
+						if (!function) {
+								fprintf(stderr, "Could not allocate memory for Sail function\n");
+								free(uppercase_keyword);
+								return NULL;
+						}
+						strncpy(function, start, length);
+						function[length] = '\0';
+						if (strstr(function, uppercase_keyword)) {
+								free(uppercase_keyword);
+								return function;
+						}
+						free(function);
+				}
+				start = strstr(start + 1, "function clause execute");
+		}
+		free(uppercase_keyword);
+		return NULL;
+}
+
+char* extract_qemu_function(const char* content, const char* keyword) {
+		char buffer[256];
+		snprintf(buffer, sizeof(buffer), "static bool trans_%s", keyword);
+		size_t keyword_length = strlen(keyword);
+
+		char* start = strstr(content, "static bool trans_");
+		while (start) {
+				char* function_name_start = start + strlen("static bool trans_");
+				char* function_name_end = strstr(function_name_start, "(");
+				if (function_name_end) {
+						size_t function_name_length = function_name_end - function_name_start;
+						if (function_name_length == keyword_length &&
+								strncasecmp(function_name_start, keyword, keyword_length) == 0) {
+								char* end = strstr(function_name_end, "}");
+								if (end) {
+										end += 1;
+										size_t length = end - start;
+										char* function = (char*)malloc(length + 1);
+										if (!function) {
+												fprintf(stderr, "Could not allocate memory for QEMU function\n");
+												return NULL;
+										}
+										strncpy(function, start, length);
+										function[length] = '\0';
+										return function;
+								}
+						}
+				}
+				start = strstr(start + 1, "static bool trans_");
+		}
+		return NULL;
+}
+
+char** extract_sail_instructions(const char* content, size_t* count) {
+	char** instructions = NULL;
+	*count = 0;
+
+	const char* clause_start = "function clause execute";
+	const char* keyword = "RISCV_";
+	const char* start = strstr(content, clause_start);
+	while (start) {
+			const char* clause_end = strstr(start, "RETIRE_SUCCESS");
+			if (!clause_end) break;
+
+			const char* keyword_start = strstr(start, keyword);
+			while (keyword_start && keyword_start < clause_end) {
+					const char* end = keyword_start + strlen(keyword);
+					while (isalnum(*end) || *end == '_') {
+							end++;
+					}
+
+					size_t length = end - keyword_start - strlen(keyword);
+					char* instruction = (char*)malloc(length + 1);
+					if (!instruction) {
+							fprintf(stderr, "Could not allocate memory for instruction\n");
+							return NULL;
+					}
+
+					strncpy(instruction, keyword_start + strlen(keyword), length);
+					instruction[length] = '\0';
+
+					instructions = (char**)realloc(instructions, (*count + 1) * sizeof(char*));
+					if (!instructions) {
+							fprintf(stderr, "Could not allocate memory for instruction array\n");
+							return NULL;
+					}
+
+					instructions[*count] = instruction;
+					(*count)++;
+
+					keyword_start = strstr(keyword_start + 1, keyword);
+			}
+			start = strstr(start + 1, clause_start);
+	}
+
+	return instructions;
+}
+
+char** extract_qemu_instructions(const char* content, size_t* count) {
+	char** instructions = NULL;
+	*count = 0;
+
+	const char* keyword = "trans_";
+	const char* start = content;
+	while ((start = strstr(start, keyword)) != NULL) {
+			const char* end = start + strlen(keyword);
+			while (isalnum(*end) || *end == '_') {
+					end++;
+			}
+
+			size_t length = end - start - strlen(keyword);
+			char* instruction = (char*)malloc(length + 1);
+			if (!instruction) {
+					fprintf(stderr, "Could not allocate memory for instruction\n");
+					return NULL;
+			}
+
+			strncpy(instruction, start + strlen(keyword), length);
+			instruction[length] = '\0';
+
+			instructions = (char**)realloc(instructions, (*count + 1) * sizeof(char*));
+			if (!instructions) {
+					fprintf(stderr, "Could not allocate memory for instruction array\n");
+					return NULL;
+			}
+
+			instructions[*count] = instruction;
+			(*count)++;
+
+			start = end;
+	}
+
+	return instructions;
+}
+
+char** find_common_instructions(char** sail_instructions, size_t sail_count, char** qemu_instructions, size_t qemu_count, size_t* common_count) {
+		char** common_instructions = NULL;
+		*common_count = 0;
+
+		for (size_t i = 0; i < sail_count; i++) {
+				to_lowercase(sail_instructions[i]);
+		}
+
+		for (size_t j = 0; j < qemu_count; j++) {
+				to_lowercase(qemu_instructions[j]);
+		}
+
+		for (size_t i = 0; i < sail_count; i++) {
+				for (size_t j = 0; j < qemu_count; j++) {
+						if (strcmp(sail_instructions[i], qemu_instructions[j]) == 0) {
+								common_instructions = (char**)realloc(common_instructions, (*common_count + 1) * sizeof(char*));
+								if (!common_instructions) {
+										fprintf(stderr, "Could not allocate memory for common instructions array\n");
+										return NULL;
+								}
+
+								common_instructions[*common_count] = strdup(sail_instructions[i]);
+								(*common_count)++;
+						}
+				}
+		}
+
+		return common_instructions;
+}
+
+InstructionMapping* create_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword) {
+		char* sail_content = read_file(sail_file);
+		if (!sail_content) return NULL;
+
+		char* qemu_content = read_file(qemu_file);
+		if (!qemu_content) {
+				free(sail_content);
+				return NULL;
+		}
+
+		char* sail_function = extract_sail_function(sail_content, keyword);
+		char* qemu_function = extract_qemu_function(qemu_content, keyword);
+
+		free(sail_content);
+		free(qemu_content);
+
+		if (!sail_function || !qemu_function) {
+				free(sail_function);
+				free(qemu_function);
+				return NULL;
+		}
+
+		InstructionMapping* mapping = (InstructionMapping*)malloc(sizeof(InstructionMapping));
+		if (!mapping) {
+				fprintf(stderr, "Could not allocate memory for instruction mapping\n");
+				free(sail_function);
+				free(qemu_function);
+				return NULL;
+		}
+
+		mapping->sail_function = sail_function;
+		mapping->qemu_function = qemu_function;
+		mapping->next = NULL;
+
+		return mapping;
+}
+
+Hashmap* init_hashmap(size_t size) {
+		Hashmap* hashmap = (Hashmap*)malloc(sizeof(Hashmap));
+		if (!hashmap) {
+				fprintf(stderr, "Could not allocate memory for hashmap\n");
+				return NULL;
+		}
+
+		hashmap->entries = (HashmapEntry*)calloc(size, sizeof(HashmapEntry));
+		if (!hashmap->entries) {
+				fprintf(stderr, "Could not allocate memory for hashmap entries\n");
+				free(hashmap);
+				return NULL;
+		}
+
+		hashmap->size = size;
+		return hashmap;
+}
+
+void insert_hashmap(Hashmap* hashmap, const char* key, char* sail_function, char* qemu_function) {
+		size_t index = 0;
+		for (size_t i = 0; i < hashmap->size; i++) {
+				if (!hashmap->entries[i].key || strcmp(hashmap->entries[i].key, key) == 0) {
+						index = i;
+						break;
+				}
+		}
+
+		if (!hashmap->entries[index].key) {
+				hashmap->entries[index].key = strdup(key);
+				hashmap->entries[index].value = NULL;
+		}
+
+		InstructionMapping* new_mapping = (InstructionMapping*)malloc(sizeof(InstructionMapping));
+		if (!new_mapping) {
+				fprintf(stderr, "Could not allocate memory for new instruction mapping\n");
+				return;
+		}
+
+		new_mapping->sail_function = sail_function;
+		new_mapping->qemu_function = qemu_function;
+		new_mapping->next = hashmap->entries[index].value;
+		hashmap->entries[index].value = new_mapping;
+}
+
+void perform_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword, Hashmap* hashmap) {
+		InstructionMapping* mapping = create_instruction_mapping(sail_file, qemu_file, keyword);
+		if (mapping) {
+				insert_hashmap(hashmap, keyword, mapping->sail_function, mapping->qemu_function);
+				free(mapping);
+		} else {
+				printf("Mapping not found for keyword: %s\n", keyword);
+		}
+}
+
+Hashmap* perform_full_instruction_mapping(const char* sail_file, const char* qemu_file) {
+		char* sail_content = read_file(sail_file);
+		char* qemu_content = read_file(qemu_file);
+
+		if (!sail_content || !qemu_content) {
+				fprintf(stderr, "Error: Could not read files\n");
+				return NULL;
+		}
+
+		size_t sail_count = 0;
+		size_t qemu_count = 0;
+
+		char** sail_instructions = extract_sail_instructions(sail_content, &sail_count);
+		char** qemu_instructions = extract_qemu_instructions(qemu_content, &qemu_count);
+
+		if (!sail_instructions || !qemu_instructions) {
+				free(sail_content);
+				free(qemu_content);
+				fprintf(stderr, "Error: Could not extract instructions\n");
+				return NULL;
+		}
+
+		size_t common_count = 0;
+		char** common_instructions = find_common_instructions(sail_instructions, sail_count, qemu_instructions, qemu_count, &common_count);
+
+		if (common_count == 0) {
+				fprintf(stderr, "No common instructions found\n");
+				return NULL;
+		}
+
+		Hashmap* hashmap = init_hashmap(common_count);
+		if (!hashmap) {
+				fprintf(stderr, "Error: Could not initialize hashmap\n");
+				return NULL;
+		}
+
+		for (size_t i = 0; i < common_count; i++) {
+				perform_instruction_mapping(sail_file, qemu_file, common_instructions[i], hashmap);
+		}
+
+		for (size_t i = 0; i < common_count; i++) {
+				free(common_instructions[i]);
+		}
+		free(common_instructions);
+		for (size_t i = 0; i < sail_count; i++) {
+				free(sail_instructions[i]);
+		}
+		free(sail_instructions);
+		for (size_t i = 0; i < qemu_count; i++) {
+				free(qemu_instructions[i]);
+		}
+		free(qemu_instructions);
+
+		free(sail_content);
+		free(qemu_content);
+
+		return hashmap;
+}
+
+void print_hashmap(const Hashmap* hashmap) {
+		printf("{\n");
+		for (size_t i = 0; i < hashmap->size; i++) {
+				if (hashmap->entries[i].key) {
+						printf("  \"%s\": {\n", hashmap->entries[i].key);
+						InstructionMapping* mapping = hashmap->entries[i].value;
+						while (mapping) {
+								// Print the sail_function and qemu_function without the labels
+								// printf("    \"sail_function\": \"%s\",\n", mapping->sail_function);
+								// printf("    \"qemu_function\": \"%s\"\n", mapping->qemu_function);
+								printf("    \"%s\",\n", mapping->sail_function);
+								printf("    \"%s\"\n", mapping->qemu_function);
+								mapping = mapping->next;
+						}
+						printf("  }");
+						if (i < hashmap->size - 1) {
+								printf(",");
+						}
+						printf("\n");
+				}
+		}
+		printf("}\n");
+}

--- a/target/riscv/mapping/instruction_mapping.h
+++ b/target/riscv/mapping/instruction_mapping.h
@@ -1,0 +1,66 @@
+/*
+ * RISC-V emulation for qemu: Instruction mapping for Sail Instruction Emulation and Qemu
+ *
+ * Copyright (c) 2024 Vedant Tewari, vtewari@uwm.edu
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 or later, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef INSTRUCTION_MAPPING_H
+#define INSTRUCTION_MAPPING_H
+
+#include <stddef.h>
+
+typedef struct InstructionMapping {
+		char* sail_function;
+		char* qemu_function;
+		struct InstructionMapping* next;
+} InstructionMapping;
+
+typedef struct {
+		char* key;
+		InstructionMapping* value;
+} HashmapEntry;
+
+typedef struct {
+		HashmapEntry* entries;
+		size_t size;
+} Hashmap;
+
+Hashmap* init_hashmap(size_t size);
+
+void insert_hashmap(Hashmap* hashmap, const char* key, char* sail_function, char* qemu_function);
+
+char* read_file(const char* filename);
+
+char* extract_sail_function(const char* content, const char* keyword);
+
+char* extract_qemu_function(const char* content, const char* keyword);
+
+InstructionMapping* create_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword);
+
+void perform_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword, Hashmap* hashmap);
+
+void print_hashmap(const Hashmap* hashmap);
+
+char** extract_sail_instructions(const char* content, size_t* count);
+
+char** extract_qemu_instructions(const char* content, size_t* count);
+
+char** find_common_instructions(char** sail_instructions, size_t sail_count, char** qemu_instructions, size_t qemu_count, size_t* common_count);
+
+void to_uppercase(char* str);
+void to_lowercase(char* str);
+
+#endif
+

--- a/target/riscv/mapping/instruction_mapping.h
+++ b/target/riscv/mapping/instruction_mapping.h
@@ -16,8 +16,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef INSTRUCTION_MAPPING_H
-#define INSTRUCTION_MAPPING_H
+#ifndef MAPPING_H
+#define MAPPING_H
 
 #include <stddef.h>
 
@@ -37,21 +37,12 @@ typedef struct {
 		size_t size;
 } Hashmap;
 
-Hashmap* init_hashmap(size_t size);
-
-void insert_hashmap(Hashmap* hashmap, const char* key, char* sail_function, char* qemu_function);
+typedef struct {
+		char* keyword;
+		char* extracted_case;
+} RelevantCase;
 
 char* read_file(const char* filename);
-
-char* extract_sail_function(const char* content, const char* keyword);
-
-char* extract_qemu_function(const char* content, const char* keyword);
-
-InstructionMapping* create_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword);
-
-void perform_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword, Hashmap* hashmap);
-
-void print_hashmap(const Hashmap* hashmap);
 
 char** extract_sail_instructions(const char* content, size_t* count);
 
@@ -59,8 +50,30 @@ char** extract_qemu_instructions(const char* content, size_t* count);
 
 char** find_common_instructions(char** sail_instructions, size_t sail_count, char** qemu_instructions, size_t qemu_count, size_t* common_count);
 
-void to_uppercase(char* str);
-void to_lowercase(char* str);
+char* extract_sail_function(const char* content, const char* keyword);
+
+char* extract_qemu_function(const char* content, const char* keyword);
+
+InstructionMapping* create_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword);
+
+Hashmap* init_hashmap(size_t size);
+
+void insert_hashmap(Hashmap* hashmap, const char* key, char* sail_function, char* qemu_function);
+
+void perform_instruction_mapping(const char* sail_file, const char* qemu_file, const char* keyword, Hashmap* hashmap);
+
+void print_hashmap(const Hashmap* hashmap);
+
+Hashmap* perform_full_instruction_mapping(const char* sail_file, const char* qemu_file);
+
+RelevantCase* extract_relevant_case(const char* sail_function, const char* keyword);
+
+char* get_rhs_of_extracted_case(const char* extracted_case);
+
+char* replace_match_with_rhs(char* sail_function, const char* keyword);
+
+Hashmap* update_hashmap_with_replacement(Hashmap* hashmap);
 
 #endif
+
 

--- a/target/riscv/mapping/riscv_insts_base.sail
+++ b/target/riscv/mapping/riscv_insts_base.sail
@@ -1,0 +1,1068 @@
+/*=======================================================================================*/
+/*  RISCV Sail Model                                                                     */
+/*                                                                                       */
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except for the snapshots of the Lem and Sail libraries                   */
+/*  in the prover_snapshots directory (which include copies of their                     */
+/*  licences), is subject to the BSD two-clause licence below.                           */
+/*                                                                                       */
+/*  Copyright (c) 2017-2023                                                              */
+/*    Prashanth Mundkur                                                                  */
+/*    Rishiyur S. Nikhil and Bluespec, Inc.                                              */
+/*    Jon French                                                                         */
+/*    Brian Campbell                                                                     */
+/*    Robert Norton-Wright                                                               */
+/*    Alasdair Armstrong                                                                 */
+/*    Thomas Bauereiss                                                                   */
+/*    Shaked Flur                                                                        */
+/*    Christopher Pulte                                                                  */
+/*    Peter Sewell                                                                       */
+/*    Alexander Richardson                                                               */
+/*    Hesham Almatary                                                                    */
+/*    Jessica Clarke                                                                     */
+/*    Microsoft, for contributions by Robert Norton-Wright and Nathaniel Wesley Filardo  */
+/*    Peter Rugg                                                                         */
+/*    Aril Computer Corp., for contributions by Scott Johnson                            */
+/*    Philipp Tomsich                                                                    */
+/*    VRULL GmbH, for contributions by its employees                                     */
+/*                                                                                       */
+/*  All rights reserved.                                                                 */
+/*                                                                                       */
+/*  This software was developed by the above within the Rigorous                         */
+/*  Engineering of Mainstream Systems (REMS) project, partly funded by                   */
+/*  EPSRC grant EP/K008528/1, at the Universities of Cambridge and                       */
+/*  Edinburgh.                                                                           */
+/*                                                                                       */
+/*  This software was developed by SRI International and the University of               */
+/*  Cambridge Computer Laboratory (Department of Computer Science and                    */
+/*  Technology) under DARPA/AFRL contract FA8650-18-C-7809 ("CIFV"), and                 */
+/*  under DARPA contract HR0011-18-C-0016 ("ECATS") as part of the DARPA                 */
+/*  SSITH research programme.                                                            */
+/*                                                                                       */
+/*  This project has received funding from the European Research Council                 */
+/*  (ERC) under the European Union’s Horizon 2020 research and innovation                */
+/*  programme (grant agreement 789108, ELVER).                                           */
+/*                                                                                       */
+/*                                                                                       */
+/*  Redistribution and use in source and binary forms, with or without                   */
+/*  modification, are permitted provided that the following conditions                   */
+/*  are met:                                                                             */
+/*  1. Redistributions of source code must retain the above copyright                    */
+/*     notice, this list of conditions and the following disclaimer.                     */
+/*  2. Redistributions in binary form must reproduce the above copyright                 */
+/*     notice, this list of conditions and the following disclaimer in                   */
+/*     the documentation and/or other materials provided with the                        */
+/*     distribution.                                                                     */
+/*                                                                                       */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''                   */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED                    */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                      */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR                  */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                         */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT                     */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF                     */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                  */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,                   */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT                   */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF                   */
+/*  SUCH DAMAGE.                                                                         */
+/*=======================================================================================*/
+
+/* ****************************************************************** */
+/* This file specifies the instructions in the base integer set.      */
+
+
+/* ****************************************************************** */
+union clause ast = UTYPE : (bits(20), regidx, uop)
+
+mapping encdec_uop : uop <-> bits(7) = {
+  RISCV_LUI   <-> 0b0110111,
+  RISCV_AUIPC <-> 0b0010111
+}
+
+mapping clause encdec = UTYPE(imm, rd, op)
+  <-> imm @ rd @ encdec_uop(op)
+
+function clause execute UTYPE(imm, rd, op) = {
+  let off : xlenbits = sign_extend(imm @ 0x000);
+  let ret : xlenbits = match op {
+    RISCV_LUI   => off,
+    RISCV_AUIPC => get_arch_pc() + off
+  };
+  X(rd) = ret;
+  RETIRE_SUCCESS
+}
+
+mapping utype_mnemonic : uop <-> string = {
+  RISCV_LUI   <-> "lui",
+  RISCV_AUIPC <-> "auipc"
+}
+
+mapping clause assembly = UTYPE(imm, rd, op)
+  <-> utype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_20(imm)
+
+/* ****************************************************************** */
+union clause ast = RISCV_JAL : (bits(21), regidx)
+
+mapping clause encdec = RISCV_JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
+  <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ rd @ 0b1101111
+
+/*
+ideally we want some syntax like
+
+mapping clause encdec = RISCV_JAL(imm @ 0b0, rd) <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ rd @ 0b1101111
+
+match bv {
+  imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] -> imm @ 0b0
+}
+
+but this is difficult
+*/
+
+function clause execute (RISCV_JAL(imm, rd)) = {
+  let t : xlenbits = PC + sign_extend(imm);
+  /* Extensions get the first checks on the prospective target address. */
+  match ext_control_check_pc(t) {
+    Ext_ControlAddr_Error(e) => {
+      ext_handle_control_check_error(e);
+      RETIRE_FAIL
+    },
+    Ext_ControlAddr_OK(target) => {
+      /* Perform standard alignment check */
+      if bit_to_bool(target[1]) & not(extension("C"))
+      then {
+        handle_mem_exception(target, E_Fetch_Addr_Align());
+        RETIRE_FAIL
+      } else {
+        X(rd) = get_next_pc();
+        set_next_pc(target);
+        RETIRE_SUCCESS
+      }
+    }
+  }
+}
+
+/* TODO: handle 2-byte-alignment in mappings */
+
+mapping clause assembly = RISCV_JAL(imm, rd)
+  <-> "jal" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_21(imm)
+
+/* ****************************************************************** */
+$[name jump and link register]
+/*!
+ * The target address is obtained by adding the sign-extended 12-bit
+ * I-immediate to the register rs1, then setting the
+ * least-significant bit of the result to zero. The address of the
+ * instruction following the jump (pc+4) is written to register rd.
+ * Register x0 can be used as the destination if the result is not
+ * required.
+ */
+union clause ast = RISCV_JALR : (bits(12), regidx, regidx)
+
+$[format I]
+mapping clause encdec = RISCV_JALR(imm, rs1, rd)
+  <-> imm @ rs1 @ 0b000 @ rd @ 0b1100111
+
+mapping clause assembly = RISCV_JALR(imm, rs1, rd)
+  <-> "jalr" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_12(imm)
+
+/* see riscv_jalr_seq.sail or riscv_jalr_rmem.sail for the execute clause. */
+
+/* ****************************************************************** */
+$[name conditional branch]
+/*!
+ * The target address for this branch instruction is determined by combining
+ * the sign-extended 13-bit immediate value with the contents of register rs1.
+ * Additionally, the least-significant bit of the result is set to zero.
+ * The condition for the branch is based on the specified operation (bop),
+ * which can be one of the following mnemonic codes:
+ *   - "beq"   : Branch if equal
+ *   - "bne"   : Branch if not equal
+ *   - "blt"   : Branch if less than (signed)
+ *   - "bge"   : Branch if greater than or equal to (signed)
+ *   - "bltu"  : Branch if less than (unsigned)
+ *   - "bgeu"  : Branch if greater than or equal to (unsigned)
+ *
+ * The branch is taken if the specified condition is true, leading to a jump
+ * to the target address. If the branch is not taken, the execution proceeds
+ * to the next instruction.
+ */
+union clause ast = BTYPE : (bits(13), regidx, regidx, bop)
+
+mapping encdec_bop : bop <-> bits(3) = {
+  RISCV_BEQ  <-> 0b000,
+  RISCV_BNE  <-> 0b001,
+  RISCV_BLT  <-> 0b100,
+  RISCV_BGE  <-> 0b101,
+  RISCV_BLTU <-> 0b110,
+  RISCV_BGEU <-> 0b111
+}
+
+mapping clause encdec = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, rs1, op)
+  <-> imm7_6 : bits(1) @ imm7_5_0 : bits(6) @ rs2 @ rs1 @ encdec_bop(op) @ imm5_4_1 : bits(4) @ imm5_0 : bits(1) @ 0b1100011
+
+function clause execute (BTYPE(imm, rs2, rs1, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken : bool = match op {
+    RISCV_BEQ  => rs1_val == rs2_val,
+    RISCV_BNE  => rs1_val != rs2_val,
+    RISCV_BLT  => rs1_val <_s rs2_val,
+    RISCV_BGE  => rs1_val >=_s rs2_val,
+    RISCV_BLTU => rs1_val <_u rs2_val,
+    RISCV_BGEU => rs1_val >=_u rs2_val
+  };
+  let t : xlenbits = PC + sign_extend(imm);
+  if taken then {
+    /* Extensions get the first checks on the prospective target address. */
+    match ext_control_check_pc(t) {
+      Ext_ControlAddr_Error(e) => {
+        ext_handle_control_check_error(e);
+        RETIRE_FAIL
+      },
+      Ext_ControlAddr_OK(target) => {
+        if bit_to_bool(target[1]) & not(extension("C")) then {
+          handle_mem_exception(target, E_Fetch_Addr_Align());
+          RETIRE_FAIL;
+        } else {
+          set_next_pc(target);
+          RETIRE_SUCCESS
+        }
+      }
+    }
+  } else RETIRE_SUCCESS
+}
+
+mapping btype_mnemonic : bop <-> string = {
+  RISCV_BEQ  <-> "beq",
+  RISCV_BNE  <-> "bne",
+  RISCV_BLT  <-> "blt",
+  RISCV_BGE  <-> "bge",
+  RISCV_BLTU <-> "bltu",
+  RISCV_BGEU <-> "bgeu"
+}
+
+mapping clause assembly = BTYPE(imm, rs2, rs1, op)
+  <-> btype_mnemonic(op) ^ spc() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_13(imm)
+
+/* ****************************************************************** */
+
+/*!
+ * The ITYPE instruction operates on an immediate value, adding, comparing, or
+ * performing bitwise operations with the contents of register rs1.
+ * The immediate value, rs1, and the operation code (iop) determine the operation.
+ * The result is stored in register rd.
+ * The supported immediate operations (iop) include:
+ *   - "addi"  : Add immediate
+ *   - "slti"  : Set less than immediate (signed)
+ *   - "sltiu" : Set less than immediate (unsigned)
+ *   - "andi"  : AND immediate
+ *   - "ori"   : OR immediate
+ *   - "xori"  : XOR immediate
+ *
+ * Note: The immediate value is sign-extended before performing the operation.
+ */
+union clause ast = ITYPE : (bits(12), regidx, regidx, iop)
+
+mapping encdec_iop : iop <-> bits(3) = {
+  RISCV_ADDI  <-> 0b000,
+  RISCV_SLTI  <-> 0b010,
+  RISCV_SLTIU <-> 0b011,
+  RISCV_ANDI  <-> 0b111,
+  RISCV_ORI   <-> 0b110,
+  RISCV_XORI  <-> 0b100
+}
+
+mapping clause encdec = ITYPE(imm, rs1, rd, op)
+  <-> imm @ rs1 @ encdec_iop(op) @ rd @ 0b0010011
+
+function clause execute (ITYPE (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result : xlenbits = match op {
+    RISCV_ADDI  => rs1_val + immext,
+    RISCV_SLTI  => zero_extend(bool_to_bits(rs1_val <_s immext)),
+    RISCV_SLTIU => zero_extend(bool_to_bits(rs1_val <_u immext)),
+    RISCV_ANDI  => rs1_val & immext,
+    RISCV_ORI   => rs1_val | immext,
+    RISCV_XORI  => rs1_val ^ immext
+  };
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+mapping itype_mnemonic : iop <-> string = {
+  $[name add immediate]
+    RISCV_ADDI  <-> "addi",
+  $[name set less than immediate]
+    RISCV_SLTI  <-> "slti",
+  $[name set less than immediate unsigned]
+    RISCV_SLTIU <-> "sltiu",
+  $[name XOR immediate]
+    RISCV_XORI  <-> "xori",
+  $[name OR immediate]
+    RISCV_ORI   <-> "ori",
+  $[name AND immediate]
+    RISCV_ANDI  <-> "andi"
+}
+
+mapping clause assembly = ITYPE(imm, rs1, rd, op)
+  <-> itype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_12(imm)
+
+/* ****************************************************************** */
+$[name Shift Immediate]
+/*!
+ * The SHIFTIOP (Shift Immediate Operation) instruction format is used for
+ * operations that involve shifting the bits of a register by an immediate
+ * value. The specific operation is determined by the opcode field, and the
+ * shift amount is specified by the immediate value (shamt). The result is
+ * written to the destination register (rd), and the source operand is the
+ * register specified by rs1. The format is common for shift-left logical
+ * immediate (SLLI), shift-right logical immediate (SRLI), and shift-right
+ * arithmetic immediate (SRAI) operations.
+ *
+ * Note: For RV32, the decoder ensures that shamt[5] = 0.
+ */
+union clause ast = SHIFTIOP : (bits(6), regidx, regidx, sop)
+
+mapping encdec_sop : sop <-> bits(3) = {
+  RISCV_SLLI <-> 0b001,
+  RISCV_SRLI <-> 0b101,
+  RISCV_SRAI <-> 0b101
+}
+
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SLLI) <-> 0b000000 @ shamt @ rs1 @ 0b001 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRLI) <-> 0b000000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRAI) <-> 0b010000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
+
+function clause execute (SHIFTIOP(shamt, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  /* the decoder guard should ensure that shamt[5] = 0 for RV32 */
+  let result : xlenbits = match op {
+    RISCV_SLLI => if   sizeof(xlen) == 32
+                  then rs1_val << shamt[4..0]
+                  else rs1_val << shamt,
+    RISCV_SRLI => if   sizeof(xlen) == 32
+                  then rs1_val >> shamt[4..0]
+                  else rs1_val >> shamt,
+    RISCV_SRAI => if   sizeof(xlen) == 32
+                  then shift_right_arith32(rs1_val, shamt[4..0])
+                  else shift_right_arith64(rs1_val, shamt)
+  };
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+mapping shiftiop_mnemonic : sop <-> string = {
+  RISCV_SLLI <-> "slli",
+  RISCV_SRLI <-> "srli",
+  RISCV_SRAI <-> "srai"
+}
+
+mapping clause assembly = SHIFTIOP(shamt, rs1, rd, op)
+  <-> shiftiop_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
+
+/* ****************************************************************** */
+
+/*!
+ * The R-type (Register-type) instruction format is used for operations
+ * that involve three registers. The specific operation is determined
+ * by the opcode and funct7 fields. The result is written to the
+ * destination register (rd), and the source operands are specified
+ * by the source registers (rs1 and rs2). The format is common for
+ * arithmetic, logical, and shift operations.
+ */
+union clause ast = RTYPE : (regidx, regidx, regidx, rop)
+
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_ADD)  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLT)  <-> 0b0000000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLTU) <-> 0b0000000 @ rs2 @ rs1 @ 0b011 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_AND)  <-> 0b0000000 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_OR)   <-> 0b0000000 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_XOR)  <-> 0b0000000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SUB)  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRA)  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
+
+function clause execute (RTYPE(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result : xlenbits = match op {
+    RISCV_ADD  => rs1_val + rs2_val,
+    RISCV_SLT  => zero_extend(bool_to_bits(rs1_val <_s rs2_val)),
+    RISCV_SLTU => zero_extend(bool_to_bits(rs1_val <_u rs2_val)),
+    RISCV_AND  => rs1_val & rs2_val,
+    RISCV_OR   => rs1_val | rs2_val,
+    RISCV_XOR  => rs1_val ^ rs2_val,
+    RISCV_SLL  => if   sizeof(xlen) == 32
+                  then rs1_val << (rs2_val[4..0])
+                  else rs1_val << (rs2_val[5..0]),
+    RISCV_SRL  => if   sizeof(xlen) == 32
+                  then rs1_val >> (rs2_val[4..0])
+                  else rs1_val >> (rs2_val[5..0]),
+    RISCV_SUB  => rs1_val - rs2_val,
+    RISCV_SRA  => if   sizeof(xlen) == 32
+                  then shift_right_arith32(rs1_val, rs2_val[4..0])
+                  else shift_right_arith64(rs1_val, rs2_val[5..0])
+  };
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+mapping rtype_mnemonic : rop <-> string = {
+  RISCV_ADD  <-> "add",
+  RISCV_SLT  <-> "slt",
+  RISCV_SLTU <-> "sltu",
+  RISCV_AND  <-> "and",
+  RISCV_OR   <-> "or",
+  RISCV_XOR  <-> "xor",
+  RISCV_SLL  <-> "sll",
+  RISCV_SRL  <-> "srl",
+  RISCV_SUB  <-> "sub",
+  RISCV_SRA  <-> "sra"
+}
+
+mapping clause assembly = RTYPE(rs2, rs1, rd, op)
+  <-> rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+
+/* ****************************************************************** */
+$[name Load]
+/*!
+ * The LOAD instruction format is used for loading data from memory into a
+ * register. The specific operation is determined by the word width (size),
+ * whether the load is signed or unsigned (is_unsigned), and memory ordering
+ * semantics (acquire, release). The result is written to the destination
+ * register (rd), and the memory address is computed by adding the immediate
+ * offset (imm) to the value in register rs1.
+ */
+union clause ast = LOAD : (bits(12), regidx, regidx, bool, word_width, bool, bool)
+
+/* unsigned loads are only present for widths strictly less than xlen,
+   signed loads also present for widths equal to xlen */
+mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false) if (word_width_bytes(size) < sizeof(xlen_bytes)) | (not(is_unsigned) & word_width_bytes(size) <= sizeof(xlen_bytes))
+  <-> imm @ rs1 @ bool_bits(is_unsigned) @ size_bits(size) @ rd @ 0b0000011 if (word_width_bytes(size) < sizeof(xlen_bytes)) | (not(is_unsigned) & word_width_bytes(size) <= sizeof(xlen_bytes))
+
+val extend_value : forall 'n, 0 < 'n <= xlen_bytes. (bool, MemoryOpResult(bits(8 * 'n))) -> MemoryOpResult(xlenbits)
+function extend_value(is_unsigned, value) = match (value) {
+  MemValue(v)     => MemValue(if is_unsigned then zero_extend(v) else sign_extend(v) : xlenbits),
+  MemException(e) => MemException(e)
+}
+
+val process_load : forall 'n, 0 < 'n <= xlen_bytes. (regidx, xlenbits, MemoryOpResult(bits(8 * 'n)), bool) -> Retired
+function process_load(rd, vaddr, value, is_unsigned) =
+  match extend_value(is_unsigned, value) {
+    MemValue(result) => { X(rd) = result; RETIRE_SUCCESS },
+    MemException(e)  => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+  }
+
+function check_misaligned(vaddr : xlenbits, width : word_width) -> bool =
+  if   plat_enable_misaligned_access() then false
+  else match width {
+         BYTE   => false,
+         HALF   => vaddr[0] == bitone,
+         WORD   => vaddr[0] == bitone | vaddr[1] == bitone,
+         DOUBLE => vaddr[0] == bitone | vaddr[1] == bitone | vaddr[2] == bitone
+       }
+
+function clause execute(LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  /* Get the address, X(rs1) + offset.
+     Some extensions perform additional checks on address validity. */
+  match ext_data_get_addr(rs1, offset, Read(Data), width) {
+    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_OK(vaddr) =>
+      if   check_misaligned(vaddr, width)
+      then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
+      else match translateAddr(vaddr, Read(Data)) {
+        TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Address(paddr, _) =>
+          match (width) {
+            BYTE =>
+              process_load(rd, vaddr, mem_read(Read(Data), paddr, 1, aq, rl, false), is_unsigned),
+            HALF =>
+              process_load(rd, vaddr, mem_read(Read(Data), paddr, 2, aq, rl, false), is_unsigned),
+            WORD =>
+              process_load(rd, vaddr, mem_read(Read(Data), paddr, 4, aq, rl, false), is_unsigned),
+            DOUBLE if sizeof(xlen) >= 64 =>
+              process_load(rd, vaddr, mem_read(Read(Data), paddr, 8, aq, rl, false), is_unsigned),
+            _ => report_invalid_width(__FILE__, __LINE__, width, "load")
+          }
+      }
+  }
+}
+
+val maybe_aq : bool <-> string
+mapping maybe_aq = {
+  true  <-> ".aq",
+  false <-> ""
+}
+
+val maybe_rl : bool <-> string
+mapping maybe_rl = {
+  true  <-> ".rl",
+  false <-> ""
+}
+
+val maybe_u : bool <-> string
+mapping maybe_u = {
+  true  <-> "u",
+  false <-> ""
+}
+
+mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, size, aq, rl)
+  <-> "l" ^ size_mnemonic(size) ^ maybe_u(is_unsigned) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_12(imm) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
+
+/* ****************************************************************** */
+$[name Store]
+/*!
+ * The STORE instruction format is used for storing data from a register into
+ * memory. The specific operation is determined by the word width (size) and
+ * memory ordering semantics (acquire, release). The memory address is computed
+ * by adding the immediate offset (imm) to the value in register rs1, and the
+ * data is taken from register rs2.
+ */
+union clause ast = STORE : (bits(12), regidx, regidx, word_width, bool, bool)
+
+mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, size, false, false)              if word_width_bytes(size) <= sizeof(xlen_bytes)
+  <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b0 @ size_bits(size) @ imm5 : bits(5) @ 0b0100011 if word_width_bytes(size) <= sizeof(xlen_bytes)
+
+/* NOTE: Currently, we only EA if address translation is successful.
+   This may need revisiting. */
+function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  /* Get the address, X(rs1) + offset.
+     Some extensions perform additional checks on address validity. */
+  match ext_data_get_addr(rs1, offset, Write(Data), width) {
+    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_OK(vaddr) =>
+      if   check_misaligned(vaddr, width)
+      then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+      else match translateAddr(vaddr, Write(Data)) {
+        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Address(paddr, _) => {
+          let eares : MemoryOpResult(unit) = match width {
+            BYTE   => mem_write_ea(paddr, 1, aq, rl, false),
+            HALF   => mem_write_ea(paddr, 2, aq, rl, false),
+            WORD   => mem_write_ea(paddr, 4, aq, rl, false),
+            DOUBLE => mem_write_ea(paddr, 8, aq, rl, false)
+          };
+          match (eares) {
+            MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            MemValue(_) => {
+              let rs2_val = X(rs2);
+              let res : MemoryOpResult(bool) = match (width) {
+                BYTE => mem_write_value(paddr, 1, rs2_val[7..0],  aq, rl, false),
+                HALF => mem_write_value(paddr, 2, rs2_val[15..0], aq, rl, false),
+                WORD => mem_write_value(paddr, 4, rs2_val[31..0], aq, rl, false),
+                DOUBLE if sizeof(xlen) >= 64
+                     => mem_write_value(paddr, 8, rs2_val,        aq, rl, false),
+                _    => report_invalid_width(__FILE__, __LINE__, width, "store"),
+              };
+              match (res) {
+                MemValue(true)  => RETIRE_SUCCESS,
+                MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+              }
+            }
+          }
+        }
+      }
+  }
+}
+
+mapping clause assembly = STORE(imm, rs2, rs1, size, aq, rl)
+  <-> "s" ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_12(imm) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
+
+/* ****************************************************************** */
+$[name Add Immediate Word]
+/*!
+ * The ADDIW instruction involves adding a sign-extended
+ * 12-bit immediate value to the content of register rs1. The result is a 32-bit
+ * value, and overflow is disregarded. The final outcome is the lower 32 bits of
+ * the result, sign-extended to 64 bits. If the immediate value is set to zero
+ * in the ADDIW rd, rs1, 0 operation, the sign-extension of the lower 32 bits
+ * of register rs1 is written to register rd.
+ */
+
+union clause ast = ADDIW : (bits(12), regidx, regidx)
+
+$[format I]
+mapping clause encdec = ADDIW(imm, rs1, rd)
+      if sizeof(xlen) == 64
+  <-> imm @ rs1 @ 0b000 @ rd @ 0b0011011
+      if sizeof(xlen) == 64
+
+function clause execute (ADDIW(imm, rs1, rd)) = {
+  let result : xlenbits = sign_extend(imm) + X(rs1);
+  X(rd) = sign_extend(result[31..0]);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = ADDIW(imm, rs1, rd)
+      if sizeof(xlen) == 64
+  <-> "addiw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_12(imm)
+      if sizeof(xlen) == 64
+
+/* ****************************************************************** */
+
+/*!
+ * The RTYPEW instruction set operates on 32-bit values,
+ * and the result is sign-extended to 64 bits. The available operations are
+ * ADDW (addition), SUBW (subtraction), SLLW (logical left shift),
+ * SRLW (logical right shift), and SRAW (arithmetic right shift).
+ * These operations are only applicable when the width of the target
+ * architecture is 64 bits.
+ */
+
+union clause ast = RTYPEW : (regidx, regidx, regidx, ropw)
+
+mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_ADDW)
+      if sizeof(xlen) == 64
+  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
+      if sizeof(xlen) == 64
+mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SUBW)
+      if sizeof(xlen) == 64
+  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
+      if sizeof(xlen) == 64
+mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SLLW)
+      if sizeof(xlen) == 64
+  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0111011
+      if sizeof(xlen) == 64
+mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRLW)
+      if sizeof(xlen) == 64
+  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0111011
+      if sizeof(xlen) == 64
+mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRAW)
+      if sizeof(xlen) == 64
+  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0111011
+      if sizeof(xlen) == 64
+
+function clause execute (RTYPEW(rs2, rs1, rd, op)) = {
+  let rs1_val = (X(rs1))[31..0];
+  let rs2_val = (X(rs2))[31..0];
+  let result : bits(32) = match op {
+    RISCV_ADDW => rs1_val + rs2_val,
+    RISCV_SUBW => rs1_val - rs2_val,
+    RISCV_SLLW => rs1_val << (rs2_val[4..0]),
+    RISCV_SRLW => rs1_val >> (rs2_val[4..0]),
+    RISCV_SRAW => shift_right_arith32(rs1_val, rs2_val[4..0])
+  };
+  X(rd) = sign_extend(result);
+  RETIRE_SUCCESS
+}
+
+mapping rtypew_mnemonic : ropw <-> string = {
+  RISCV_ADDW <-> "addw",
+  RISCV_SUBW <-> "subw",
+  RISCV_SLLW <-> "sllw",
+  RISCV_SRLW <-> "srlw",
+  RISCV_SRAW <-> "sraw"
+}
+
+mapping clause assembly = RTYPEW(rs2, rs1, rd, op)
+      if sizeof(xlen) == 64
+  <-> rtypew_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+      if sizeof(xlen) == 64
+
+/* ****************************************************************** */
+$[name Shift Immediate Word]
+/*!
+ * The SHIFTIWOP instruction set deals with
+ * immediate shift operations on 32-bit values, with the result sign-extended
+ * to 64 bits. The available operations include SLLIW (left shift logical
+ * immediate word), SRLIW (right shift logical immediate word), and SRAIW
+ * (right shift arithmetic immediate word). These operations are applicable
+ * when the target architecture has a width of 64 bits.
+ */
+
+union clause ast = SHIFTIWOP : (bits(5), regidx, regidx, sopw)
+
+mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SLLIW)
+      if sizeof(xlen) == 64
+  <-> 0b0000000 @ shamt @ rs1 @ 0b001 @ rd @ 0b0011011
+      if sizeof(xlen) == 64
+mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRLIW)
+      if sizeof(xlen) == 64
+  <-> 0b0000000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0011011
+      if sizeof(xlen) == 64
+mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRAIW)
+      if sizeof(xlen) == 64
+  <-> 0b0100000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0011011
+      if sizeof(xlen) == 64
+
+function clause execute (SHIFTIWOP(shamt, rs1, rd, op)) = {
+  let rs1_val = (X(rs1))[31..0];
+  let result : bits(32) = match op {
+    RISCV_SLLIW => rs1_val << shamt,
+    RISCV_SRLIW => rs1_val >> shamt,
+    RISCV_SRAIW => shift_right_arith32(rs1_val, shamt)
+  };
+  X(rd) = sign_extend(result);
+  RETIRE_SUCCESS
+}
+
+mapping shiftiwop_mnemonic : sopw <-> string = {
+  RISCV_SLLIW <-> "slliw",
+  RISCV_SRLIW <-> "srliw",
+  RISCV_SRAIW <-> "sraiw"
+}
+
+mapping clause assembly = SHIFTIWOP(shamt, rs1, rd, op)
+      if sizeof(xlen) == 64
+  <-> shiftiwop_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_5(shamt)
+      if sizeof(xlen) == 64
+
+/* ****************************************************************** */
+$[name Fence (Memory)]
+/*!
+ * The FENCE instruction is used to provide memory ordering guarantees.
+ * It specifies ordering constraints on memory operations that precede
+ * and follow it in program order. The FENCE instruction includes two
+ * 4-bit fields, 'pred' and 'succ', which represent the memory ordering
+ * requirements before and after the FENCE instruction, respectively.
+ *
+ * The bits in 'pred' and 'succ' represent the following ordering constraints:
+ * - 'i': instruction stream order
+ * - 'o': outstanding loads
+ * - 'r': read operations
+ * - 'w': write operations
+ *
+ * The FENCE instruction is used to control the visibility of memory
+ * operations, and its behavior is influenced by the 'pred' and 'succ'
+ * fields. The precise semantics of the FENCE instruction depend on the
+ * specific bits set in these fields.
+ */
+union clause ast = FENCE : (bits(4), bits(4))
+
+$[format I]
+mapping clause encdec = FENCE(pred, succ)
+  <-> 0b0000 @ pred @ succ @ 0b00000 @ 0b000 @ 0b00000 @ 0b0001111
+
+function effective_fence_set(set : bits(4), fiom : bool) -> bits(4) = {
+  // The bits are IORW. If FIOM is set then I implies R and O implies W.
+  if fiom then {
+    set[3 .. 2] @ (set[1 .. 0] | set[3 .. 2])
+  } else set
+}
+
+/* For future versions of Sail where barriers can be parameterised */
+$ifdef FEATURE_UNION_BARRIER
+
+function clause execute (FENCE(pred, succ)) = {
+  // If the FIOM bit in menvcfg/senvcfg is set then the I/O bits can imply R/W.
+  let fiom = is_fiom_active();
+  let pred = effective_fence_set(pred, fiom);
+  let succ = effective_fence_set(succ, fiom);
+
+  match (pred, succ) {
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_rw_rw()),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_r_rw()),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b10) => __barrier(Barrier_RISCV_r_r()),
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b01) => __barrier(Barrier_RISCV_rw_w()),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b01) => __barrier(Barrier_RISCV_w_w()),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_w_rw()),
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b10) => __barrier(Barrier_RISCV_rw_r()),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b01) => __barrier(Barrier_RISCV_r_w()),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b10) => __barrier(Barrier_RISCV_w_r()),
+
+    (_ : bits(4)       , _ : bits(2) @ 0b00) => (),
+    (_ : bits(2) @ 0b00, _ : bits(4)       ) => (),
+
+    _ => { print("FIXME: unsupported fence");
+           () }
+  };
+  RETIRE_SUCCESS
+}
+
+$else
+
+function clause execute (FENCE(pred, succ)) = {
+  // If the FIOM bit in menvcfg/senvcfg is set then the I/O bits can imply R/W.
+  let fiom = is_fiom_active();
+  let pred = effective_fence_set(pred, fiom);
+  let succ = effective_fence_set(succ, fiom);
+
+  match (pred, succ) {
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_rw_rw),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_r_rw),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b10) => __barrier(Barrier_RISCV_r_r),
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b01) => __barrier(Barrier_RISCV_rw_w),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b01) => __barrier(Barrier_RISCV_w_w),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_w_rw),
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b10) => __barrier(Barrier_RISCV_rw_r),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b01) => __barrier(Barrier_RISCV_r_w),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b10) => __barrier(Barrier_RISCV_w_r),
+
+    (_ : bits(4)       , _ : bits(2) @ 0b00) => (),
+    (_ : bits(2) @ 0b00, _ : bits(4)       ) => (),
+
+    _ => { print("FIXME: unsupported fence");
+           () }
+  };
+  RETIRE_SUCCESS
+}
+
+$endif
+
+mapping bit_maybe_r : bits(1) <-> string = {
+  0b1 <-> "r",
+  0b0 <-> ""
+}
+
+mapping bit_maybe_w : bits(1) <-> string = {
+  0b1 <-> "w",
+  0b0 <-> ""
+}
+
+mapping bit_maybe_i : bits(1) <-> string = {
+  0b1 <-> "i",
+  0b0 <-> ""
+}
+
+mapping bit_maybe_o : bits(1) <-> string = {
+  0b1 <-> "o",
+  0b0 <-> ""
+}
+
+mapping fence_bits : bits(4) <-> string = {
+  i : bits(1) @ o : bits(1) @ r : bits(1) @ w : bits(1) <-> bit_maybe_i(i) ^ bit_maybe_o(o) ^ bit_maybe_r(r) ^ bit_maybe_w(w)
+}
+
+mapping clause assembly = FENCE(pred, succ)
+  <-> "fence" ^ spc() ^ fence_bits(pred) ^ sep() ^ fence_bits(succ)
+
+/* ****************************************************************** */
+$[name Fence (Total Store Order)]
+/*!
+ * The FENCE_TSO instruction is a memory
+ * ordering instruction that provides a stronger memory consistency model
+ * compared to the standard FENCE instruction. It ensures that all memory
+ * operations preceding and following the FENCE_TSO instruction are globally
+ * ordered. The FENCE_TSO instruction includes two 4-bit fields, 'pred' and
+ * 'succ', which represent the memory ordering requirements before and after
+ * the FENCE_TSO instruction, respectively.
+ */
+union clause ast = FENCE_TSO : (bits(4), bits(4))
+
+$[format I]
+mapping clause encdec = FENCE_TSO(pred, succ)
+  <-> 0b1000 @ pred @ succ @ 0b00000 @ 0b000 @ 0b00000 @ 0b0001111
+
+$ifdef FEATURE_UNION_BARRIER
+
+function clause execute (FENCE_TSO(pred, succ)) = {
+  match (pred, succ) {
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_tso()),
+    (_ : bits(2) @ 0b00, _ : bits(2) @ 0b00) => (),
+
+    _ => { print("FIXME: unsupported fence");
+           () }
+  };
+  RETIRE_SUCCESS
+}
+
+$else
+
+function clause execute (FENCE_TSO(pred, succ)) = {
+  match (pred, succ) {
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b11) => __barrier(Barrier_RISCV_tso),
+    (_ : bits(2) @ 0b00, _ : bits(2) @ 0b00) => (),
+
+    _ => { print("FIXME: unsupported fence");
+           () }
+  };
+  RETIRE_SUCCESS
+}
+
+$endif
+
+mapping clause assembly = FENCE_TSO(pred, succ)
+  <-> "fence.tso" ^ spc() ^ fence_bits(pred) ^ sep() ^ fence_bits(succ)
+
+/* ****************************************************************** */
+$[name Fence (Instruction)]
+/*!
+ * The FENCEI instruction is a memory ordering instruction that
+ * provides a barrier to the instruction stream.
+ * It ensures that all instructions preceding the FENCEI instruction are
+ * globally ordered. The FENCEI instruction has no 'pred' or 'succ' fields,
+ * and it is typically used to control instruction stream visibility.
+ */
+union clause ast = FENCEI : unit
+
+mapping clause encdec = FENCEI()
+  <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111
+
+/* fence.i is a nop for the memory model */
+function clause execute FENCEI() = { /* __barrier(Barrier_RISCV_i); */ RETIRE_SUCCESS }
+
+mapping clause assembly = FENCEI() <-> "fence.i"
+
+/* ****************************************************************** */
+$[name Environment Call]
+/*!
+ * The ECALL instruction, previously called SCALL is used to make a
+ * request to the supporting execution environment, typically an
+ * operating system. The ABI for the system defines how parameters
+ * for the environment request are passed, often in defined locations
+ * in the integer register file.
+ */
+union clause ast = ECALL : unit
+
+mapping clause encdec = ECALL()
+  <-> 0b000000000000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause execute ECALL() = {
+  let t : sync_exception =
+    struct { trap = match (cur_privilege) {
+                      User       => E_U_EnvCall(),
+                      Supervisor => E_S_EnvCall(),
+                      Machine    => E_M_EnvCall()
+                    },
+             excinfo = (None() : option(xlenbits)),
+             ext     = None() };
+  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC));
+  RETIRE_FAIL
+}
+
+mapping clause assembly = ECALL() <-> "ecall"
+
+/* ****************************************************************** */
+$[name Machine-level Return]
+/*!
+ * The MRET instruction is used to return from a machine-level exception,
+ * transferring control back to the instruction following the one that
+ * caused the exception. It is only valid when executed in Machine mode.
+ */
+union clause ast = MRET : unit
+
+mapping clause encdec = MRET()
+  <-> 0b0011000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause execute MRET() = {
+  if   cur_privilege != Machine
+  then { handle_illegal(); RETIRE_FAIL }
+  else if not(ext_check_xret_priv (Machine))
+  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  else {
+    set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
+    RETIRE_SUCCESS
+  }
+}
+
+mapping clause assembly = MRET() <-> "mret"
+
+/* ****************************************************************** */
+$[name Supervisor-level Return]
+/*!
+ * The SRET instruction is used to return from a supervisor-level exception,
+ * transferring control back to the instruction following the one that
+ * caused the exception. It is only valid when executed in Supervisor mode.
+ */
+union clause ast = SRET : unit
+
+mapping clause encdec = SRET()
+  <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause execute SRET() = {
+  let sret_illegal : bool = match cur_privilege {
+    User       => true,
+    Supervisor => not(extension("S")) | mstatus.TSR() == 0b1,
+    Machine    => not(extension("S"))
+  };
+  if   sret_illegal
+  then { handle_illegal(); RETIRE_FAIL }
+  else if not(ext_check_xret_priv (Supervisor))
+  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  else {
+    set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
+    RETIRE_SUCCESS
+  }
+}
+
+mapping clause assembly = SRET() <-> "sret"
+
+/* ****************************************************************** */
+$[name Environment Breakpoint]
+/*!
+ * The EBREAK instruction, previously called SBREAK is utilized by
+ * debuggers to trigger a breakpoint exception, leading to a transfer
+ * of control back to a debugging environment.
+ * This instruction is commonly employed for debugging purposes.
+ */
+union clause ast = EBREAK : unit
+
+mapping clause encdec = EBREAK()
+  <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause execute EBREAK() = {
+  handle_mem_exception(PC, E_Breakpoint());
+  RETIRE_FAIL
+}
+
+mapping clause assembly = EBREAK() <-> "ebreak"
+
+/* ****************************************************************** */
+$[name Wait For Interrupt]
+/*!
+ * The WFI (Wait For Interrupt) instruction is used to suspend the execution
+ * pipeline until an interrupt or an event occurs. Its behavior depends on the
+ * current privilege level:
+ * - In Machine mode, it invokes the platform-specific WFI handler.
+ * - In Supervisor mode, it checks the TW (Timer Wait) bit in mstatus. If the
+ *   bit is set, it handles the illegal instruction and returns with RETIRE_FAIL.
+ *   Otherwise, it invokes the platform-specific WFI handler.
+ * - In User mode, it handles the illegal instruction and returns with RETIRE_FAIL.
+ */
+union clause ast = WFI : unit
+
+mapping clause encdec = WFI()
+  <-> 0b000100000101 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause execute WFI() =
+  match cur_privilege {
+    Machine    => { platform_wfi(); RETIRE_SUCCESS },
+    Supervisor => if   mstatus.TW() == 0b1
+                  then { handle_illegal(); RETIRE_FAIL }
+                  else { platform_wfi(); RETIRE_SUCCESS },
+    User       => { handle_illegal(); RETIRE_FAIL }
+  }
+
+mapping clause assembly = WFI() <-> "wfi"
+
+/* ****************************************************************** */
+$[name Store Fence (Virtual Memory Address)]
+/*!
+ * The SFENCE.VMA instruction is used to synchronize the store queue and flush
+ * TLB entries based on virtual memory address and optional ASID values.
+ * Its behavior depends on the current privilege level:
+ * - In User mode, it handles the illegal instruction and returns with RETIRE_FAIL.
+ * - In Supervisor mode, it checks for illegal instructions and performs TLB
+ *   flushing based on the provided virtual memory address and ASID values.
+ * - In Machine mode, it performs TLB flushing based on the provided virtual
+ *   memory address and ASID values.
+ */
+
+union clause ast = SFENCE_VMA : (regidx, regidx)
+
+$[format R]
+mapping clause encdec = SFENCE_VMA(rs1, rs2)
+  <-> 0b0001001 @ rs2 @ rs1 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause execute SFENCE_VMA(rs1, rs2) = {
+  let addr : option(xlenbits) = if rs1 == 0b00000 then None() else Some(X(rs1));
+  let asid : option(xlenbits) = if rs2 == 0b00000 then None() else Some(X(rs2));
+  match cur_privilege {
+    User       => { handle_illegal(); RETIRE_FAIL },
+    Supervisor => match (architecture(get_mstatus_SXL(mstatus)), mstatus.TVM()) {
+                    (Some(_), 0b1)  => { handle_illegal(); RETIRE_FAIL },
+                    (Some(_), 0b0) => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+                    (_, _)           => internal_error(__FILE__, __LINE__, "unimplemented sfence architecture")
+                  },
+    Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS }
+  }
+}
+
+mapping clause assembly = SFENCE_VMA(rs1, rs2)
+  <-> "sfence.vma" ^ spc() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)


### PR DESCRIPTION
# Project Proposal: Sail to QEMU Target Downstream Task Issue 

The goal of this project is to perhaps create a generated RVI-32/64 translation for QEMU, we hope to utilize Sail as the source for conversion.

## The following files are involved:

- `/model/riscv_insts_base.sail`  
  [Link to file](https://github.com/riscv/sail-riscv/blob/master/model/riscv_insts_base.sail)
  
- `target/riscv/insn_trans/trans_rvi.c.inc`  
  [Link to file](https://github.com/qemu/qemu/blob/master/target/riscv/insn_trans/trans_rvi.c.inc)

## Below is the following representation/translation in both the files of importance:

### Load Upper Immediate instruction

**Sail code (`model/riscv_insts_base.sail`):**
```sail
function clause execute UTYPE(imm, rd, op) = {
  let off : xlenbits = sign_extend(imm @ 0x000);
  let ret : xlenbits = match op {
    RISCV_LUI   => off,
    RISCV_AUIPC => get_arch_pc() + off
  };
  X(rd) = ret;
  RETIRE_SUCCESS
}
```
QEMU code (target/riscv/insn_trans/trans_rvi.c.inc):

```c
static bool trans_lui(DisasContext *ctx, arg_lui *a)
{
    gen_set_gpri(ctx, a->rd, a->imm);
    return true;
}
```

- static bool: standard template
- trans_: standard template
- lui: mnemonic. This could come from parsing the Sail code “mapping clause assembly” directly:

```sail
mapping utype_mnemonic : uop <-> string = {
  RISCV_LUI   <-> "lui",
  RISCV_AUIPC <-> "auipc"
}

mapping clause assembly = UTYPE(imm, rd, op)
  <-> utype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_20(imm)
```

OR, it could come from the JSON, which includes the mnemonic and the Sail function clause execute for the mnemonic.

- (DisasContext *ctx, arg_: standard template

- lui: mnemonic

- *a: standard template

- gen_set_gpri(ctx, a->[register], a->[immediate]): map from Sail construct X(register) = immediate pattern

Need to understand conventions for names of structure fields, like rd and imm in both the Sail code and the QEMU code.

- return true: standard template

## Standard Template
A standard template would look like:

```c
static bool trans_[mnemonic] (DisasContext *ctx, arg_[mnemonic] *a)
{
    [code]
    return true;
}
```

And the pattern matching database would include, to start:

| Sail Representation  | QEMU Representation                                      |
|----------------------|----------------------------------------------------------|
| X(register) = value  | gen_set_gpri(ctx, a->register, a->immediate)             |


## Translating from the Sail code
Translating from the Sail code involves just working with the code that specifies actions:

```sail
let off : xlenbits = sign_extend(imm @ 0x000);
let ret : xlenbits = match op {
  RISCV_LUI   => off,
  RISCV_AUIPC => get_arch_pc() + off
};
X(rd) = ret;
```
Note that for Load Upper Immediate, only the code associated with RISCV_LUI is executed. This will have to be understood also through parsing the mapping clause assembly and finding that RISCV_LUI is associated exclusively with the lui mnemonic.

- let off : xlenbits = sign_extend(imm @ 0x000);
In QEMU, this shift and sign extend is done before trans_lui is called, presumably as a normal part of decoding a “U Format” instruction.
So, this line can be ignored in translation from Sail to QEMU.

## Add Upper Immediate to PC
Looking to another, similar instruction, Add Upper Immediate to PC, Sail code is above (same as Load Upper Immediate).

QEMU code:

```c
static bool trans_auipc(DisasContext *ctx, arg_auipc *a)
{
    TCGv target_pc = dest_gpr(ctx, a->rd);
    gen_pc_plus_diff(target_pc, ctx, a->imm);
    gen_set_gpr(ctx, a->rd, target_pc);
    return true;
}
```
### Initial Patch Example
An initial local patch ([Link to commit](https://github.com/qemu/qemu/commit/aa675e3f44a0b5f7528f5d73f24f865b37735901)) was created to demonstrate the mapping of the form:

```
{
  "lui": {
    "function clause execute UTYPE(imm, rd, op) = {
    let off : xlenbits = sign_extend(imm @ 0x000);
    let ret : xlenbits = match op {
        RISCV_LUI   => off,
        RISCV_AUIPC => get_arch_pc() + off
    };
    X(rd) = ret;
    RETIRE_SUCCESS",
    "static bool trans_lui(DisasContext *ctx, arg_lui *a)
{
        gen_set_gpri(ctx, a->rd, a->imm);
        return true;
}"
  },
  "auipc": {
    "function clause execute UTYPE(imm, rd, op) = {
    let off : xlenbits = sign_extend(imm @ 0x000);
    let ret : xlenbits = match op {
        RISCV_LUI   => off,
        RISCV_AUIPC => get_arch_pc() + off
    };
    X(rd) = ret;
    RETIRE_SUCCESS",
    "static bool trans_auipc(DisasContext *ctx, arg_auipc *a)
{
        TCGv target_pc = dest_gpr(ctx, a->rd);
        gen_pc_plus_diff(target_pc, ctx, a->imm);
        gen_set_gpr(ctx, a->rd, target_pc);
        return true;
}"
}
...
```
This is another pattern to be added to the translation database:

| Sail                            | QEMU                                               |
|---------------------------------|----------------------------------------------------|
| `variable = get_arch_pc() + offset` | `target_pc = dest_gpr(ctx, a->rd)`                  |
|                                 | `gen_pc_plus_diff(target_pc, ctx, a->imm)`         |

---

Where the format of the map is:

Map<String, pair<Sail_Instruction_Representation, QEMU_Instruction_Representation>>
The template is consistent, so only the code needs to be translated.

We were hoping to get suggestions and feedback from the community and maintainers based on this task, using the output of the example files used to create a base mapping.

We hope to create a webpage representing the instruction mappings, that the community itself could refer to. We are in the process of constructing a universal page dedicated to these translations across several downstream projects, so it could be referred to and reviewed by those interested in generation/translation of instruction representation across several projects compared against each other.
