### PR TITLE
remove thread and disable stop migrate

### DIFF
--- a/include/standard-headers/linux/kvm_para.h
+++ b/include/standard-headers/linux/kvm_para.h
@@ -30,7 +30,7 @@
 #define KVM_HC_SEND_IPI		10
 #define KVM_HC_SCHED_YIELD		11
 #define KVM_HC_MAP_GPA_RANGE		12
-
+#define KVM_HC_FORK_VM         13
 /*
  * hypercalls use architecture specific
  */

--- a/include/sysemu/sysemu.h
+++ b/include/sysemu/sysemu.h
@@ -99,6 +99,7 @@ bool defaults_enabled(void);
 void qemu_init(int argc, char **argv);
 int qemu_main_loop(void);
 void qemu_cleanup(int);
+int qemu_get_args(char **argv);
 
 extern QemuOptsList qemu_legacy_drive_opts;
 extern QemuOptsList qemu_common_drive_opts;

--- a/include/sysemu/sysemu.h
+++ b/include/sysemu/sysemu.h
@@ -99,7 +99,7 @@ bool defaults_enabled(void);
 void qemu_init(int argc, char **argv);
 int qemu_main_loop(void);
 void qemu_cleanup(int);
-int qemu_get_args(char **argv);
+int qemu_get_args(char ***argvp);
 
 extern QemuOptsList qemu_legacy_drive_opts;
 extern QemuOptsList qemu_common_drive_opts;

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('qemu', ['c'], meson_version: '>=1.1.0',
         default_options: ['warning_level=1', 'c_std=gnu11', 'cpp_std=gnu++11', 'b_colorout=auto',
-                          'b_staticpic=false', 'stdsplit=false', 'optimization=2', 'b_pie=true'],
+                          'b_staticpic=false', 'stdsplit=false', 'optimization=0', 'b_pie=true'],
         version: files('VERSION'))
 
 add_test_setup('quick', exclude_suites: ['slow', 'thorough'], is_default: true)

--- a/migration/channel.h
+++ b/migration/channel.h
@@ -25,6 +25,11 @@ void migration_channel_connect(MigrationState *s,
                                const char *hostname,
                                Error *error_in);
 
+void migration_channel_connect_without_thread(MigrationState *s,
+                               QIOChannel *ioc,
+                               const char *hostname,
+                               Error *error_in);
+
 int migration_channel_read_peek(QIOChannel *ioc,
                                 const char *buf,
                                 const size_t buflen,

--- a/migration/file.h
+++ b/migration/file.h
@@ -17,6 +17,8 @@ void file_start_incoming_migration(FileMigrationArgs *file_args, Error **errp);
 
 void file_start_outgoing_migration(MigrationState *s,
                                    FileMigrationArgs *file_args, Error **errp);
+void file_start_outgoing_migration_without_thread(MigrationState *s,
+                                   FileMigrationArgs *file_args, Error **errp);
 int file_parse_offset(char *filespec, uint64_t *offsetp, Error **errp);
 void file_cleanup_outgoing_migration(void);
 bool file_send_channel_create(gpointer opaque, Error **errp);

--- a/migration/migration.c
+++ b/migration/migration.c
@@ -3320,6 +3320,8 @@ static void migration_iteration_finish(MigrationState *s)
         error_report("%s: Unknown ending state %d", __func__, s->state);
         break;
     }
+    if (strcmp(s->hostname, "forkhost"))
+        runstate_set(RUN_STATE_RUNNING);
 
     migration_bh_schedule(migrate_fd_cleanup_bh, s);
     bql_unlock();

--- a/migration/migration.h
+++ b/migration/migration.h
@@ -472,6 +472,7 @@ void migrate_set_error(MigrationState *s, const Error *error);
 bool migrate_has_error(MigrationState *s);
 
 void migrate_fd_connect(MigrationState *s, Error *error_in);
+void migrate_fd_connect_without_thread(MigrationState *s, Error *error_in);
 
 int migration_call_notifiers(MigrationState *s, MigrationEventType type,
                              Error **errp);

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -178,6 +178,20 @@ SRST
     selection)
 ERST
 
+DEF("forkable", HAS_ARG, QEMU_OPTION_forkable,
+    "-forkable path   mark this vm as a forkable vm\n", QEMU_ARCH_ALL)
+SRST
+``-forkable``
+    Mark this vm as a forkable vm and move image file to given path.
+ERST
+
+DEF("forked", HAS_ARG, QEMU_OPTION_forked,
+    "-forked path   Restore vm from path\n", QEMU_ARCH_ALL)
+SRST
+``-forked``
+    Restore vm from path.
+ERST
+
 DEF("accel", HAS_ARG, QEMU_OPTION_accel,
     "-accel [accel=]accelerator[,prop[=value][,...]]\n"
     "                select accelerator (kvm, xen, hvf, nvmm, whpx or tcg; use 'help' for a list)\n"

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -192,6 +192,13 @@ SRST
     Restore vm from path.
 ERST
 
+DEF("forkgroup", HAS_ARG, QEMU_OPTION_forkgroup,
+    "-forkgroup id      Set fork group id\n", QEMU_ARCH_ALL)
+SRST
+``-forkgroup``
+    Set this fork group's id.
+ERST
+
 DEF("accel", HAS_ARG, QEMU_OPTION_accel,
     "-accel [accel=]accelerator[,prop[=value][,...]]\n"
     "                select accelerator (kvm, xen, hvf, nvmm, whpx or tcg; use 'help' for a list)\n"

--- a/system/vl.c
+++ b/system/vl.c
@@ -525,8 +525,24 @@ static QemuOptsList qemu_forked_opts = {
     .head = QTAILQ_HEAD_INITIALIZER(qemu_forked_opts.head),
     .desc = {
         {
-            .name = "src",
+            .name = "path",
             .type = QEMU_OPT_STRING,
+        },{
+            .name = "filename",
+            .type = QEMU_OPT_STRING,
+        },
+        { /* end of list */ }
+    },
+};
+
+static QemuOptsList qemu_forkgroup_opts = {
+    .name = "forkgroup",
+    .merge_lists = true,
+    .head = QTAILQ_HEAD_INITIALIZER(qemu_forkgroup_opts.head),
+    .desc = {
+        {
+            .name = "id",
+            .type = QEMU_OPT_NUMBER,
         },
         { /* end of list */ }
     },
@@ -2785,7 +2801,8 @@ int qemu_get_args(char ***argv_p)
 static void qemu_copy_forkable_image(const QDict *machine_opts)
 {
     const char *kernel_path = qdict_get_try_str(machine_opts, "kernel");
-    QemuOpts opts = qemu_find_opts_singleton("forkable");
+    //QemuOptsList *list = qemu_find_opts("forkable");
+    QemuOpts *opts = qemu_find_opts_singleton("forkable");
     const char *copy_path = qemu_opt_get(opts, "path");
     //const char *copy_path = qdict_get_try_str(machine_opts, "imgpath");
 
@@ -2799,11 +2816,10 @@ static void qemu_copy_forkable_image(const QDict *machine_opts)
             /* Throw error */
         }
     }
-    return;
 }
 
 /* Copy argc and argv to global variable */
-static void qemu_copy_args(int argc, char **argv){
+static int qemu_copy_args(int argc, char **argv){
     global_argc = argc;
     global_argv = (char **)g_malloc((argc + 1) * sizeof(char *));
     g_assert(global_argv);
@@ -2869,6 +2885,7 @@ void qemu_init(int argc, char **argv)
     qemu_add_opts(&qemu_action_opts);
     qemu_add_opts(&qemu_forkable_opts);
     qemu_add_opts(&qemu_forked_opts);
+    qemu_add_opts(&qemu_forkgroup_opts);
     qemu_add_run_with_opts();
     module_call_init(MODULE_INIT_OPTS);
 
@@ -2929,6 +2946,9 @@ void qemu_init(int argc, char **argv)
                 break;
             case QEMU_OPTION_forked:
                 //TODO: begin migrate
+                break;
+            case QEMU_OPTION_forkgroup:
+                //TODO: Set group id
                 break;
             case QEMU_OPTION_cpu:
                 /* hw initialization will check this */

--- a/target/i386/kvm/kvm.c
+++ b/target/i386/kvm/kvm.c
@@ -6034,6 +6034,10 @@ extern void qmp_migrate(const char *uri, bool has_channels,
                  MigrationChannelList *channels, bool has_detach, bool detach,
                  bool has_resume, bool resume, Error **errp);
 
+extern void forkd_migrate(const char *uri, bool has_channels,
+                 MigrationChannelList *channels, bool has_detach, bool detach,
+                 bool has_resume, bool resume, Error **errp);
+
 /*
  * 1. Boot a new vm with -forked flag, the new vm will waiting for incoming 
  *    data.
@@ -6116,8 +6120,10 @@ static int kvm_handle_hc_fork_vm(struct kvm_run *run)
     sprintf(uri, "file:%s/%s", migrate_path, migrate_filename);
     MigrationState *s = migrate_get_current();
     s->hostname = g_strdup("forkhost");
-    qmp_migrate(uri, false, NULL, false, false, false, false, &err);
-    pause();
+//    qmp_migrate(uri, false, NULL, false, false, false, false, &err);
+//    pause();
+
+    forkd_migrate(uri, false, NULL, false, false, false, false, &err);
     /* Return child pid */
     return child_pid;
 }

--- a/target/i386/kvm/kvm.c
+++ b/target/i386/kvm/kvm.c
@@ -5866,11 +5866,39 @@ static int kvm_handle_hc_map_gpa_range(struct kvm_run *run)
     return kvm_convert_memory(gpa, size, attributes & KVM_MAP_GPA_RANGE_ENCRYPTED);
 }
 
+static char *parse_args_to_str(){
+
+}
+
+/*
+ * 1. Boot a new vm with -forked flag, the new vm will waiting for incoming 
+ *    data.
+ * 2. Call modified migration function to begin copy process.
+ * 3. Wait until all of copy process finished.
+ * 4. Return the new pid assigned to the new vm.
+ */
+static int kvm_handle_hc_fork_vm(struct kvm_run *run){
+    /* Get this vm's parameter */
+    int argc;
+    char **argv;
+    char *request;
+    argc = qemu_get_args(&argv);
+    /* Parse the parameter to boot a new VM */
+    
+    /* Send request to forkd */
+    
+    /* Receive boot signal */
+
+    /* Begin transport */
+
+}
+
 static int kvm_handle_hypercall(struct kvm_run *run)
 {
     if (run->hypercall.nr == KVM_HC_MAP_GPA_RANGE)
         return kvm_handle_hc_map_gpa_range(run);
-
+    if (run->hypercall.nr == KVM_HC_FORK_VM)
+        return kvm_handle_hc_fork_vm(run);
     return -EINVAL;
 }
 


### PR DESCRIPTION
去掉了原来的迁移线程，直接将迁移逻辑放在主线程，在migrate_fd_connect_without_thread中的do_migration_work。
在迁移逻辑中删除了停止调用VM的逻辑，在migration_stop_vm_without_stopvm处。

然后在构建qemu的时候需要在build文件夹中的qapi/qapi-commands-migration.h文件添加forkd_migrate声明，否则编译的时候报错：
![image](https://github.com/user-attachments/assets/fec93059-d4f6-4dc8-899e-071052b96a01)
