### PR TITLE
Docs: Update copyright year to 2026

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ default_role = 'any'
 
 # General information about the project.
 project = u'QEMU'
-copyright = u'2025, The QEMU Project Developers'
+copyright = u'2026, The QEMU Project Developers'
 author = u'The QEMU Project Developers'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
I've updated the copyright year in the Sphinx documentation configuration file (docs/conf.py) from 2025 to 2026.