### PR TITLE
xen/passthrough: add missing error-report include

### DIFF
--- a/hw/xen/xen_pt.c
+++ b/hw/xen/xen_pt.c
@@ -54,6 +54,7 @@
 
 #include "qemu/osdep.h"
 #include "qapi/error.h"
+#include "qemu/error-report.h"
 #include <sys/ioctl.h>
 
 #include "hw/pci/pci.h"


### PR DESCRIPTION
In cfcacba an `error_report` was added to this file, but the corresponding include of `qemu/error-report.h` was missed. This only becomes apparent when building against Xen 4.20+.